### PR TITLE
[MVP1][F06] Observabilidade e Logging

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -18,6 +18,7 @@
 |---|---|---|
 | 2026-07-22 | **Prioridade no board via marcador único `proplan:next`** (Opção A). A ordem completa da fila vive só no `docs/STATUS.md` (fonte única); `next` projeta a cabeça dela no board. Marcador, não coluna — coexiste com `proplan:backlog`, no máximo um aberto. Rejeitada a ordenação ordinal no título/label (viraria segunda fonte da fila → drift). Registrado em CONVENTION §1. | PI |
 | 2026-07-22 | **SPEC-Fundacao-06 emendada:** critério 5 e nota de escopo corrigidos — instrumentação de `auth`/`workspace-switch`/`db` migra para F03/F02/F04 (cada uma com critério de aceite de logging dedicado), porque esse código não existe quando o F06 executa. O F06 entrega infra + contrato (CONVENTION §3) e instrumenta só `ipc`/`sistema`. | PI |
+| 2026-07-22 | **Ordem F04 antes de F02 no MVP-001** (fila `01 → 06 → 04 → 02 → 03 → 05`). PI delegou a decisão ao Cowork; rationale: F02/F03 consomem os contratos tipados da F04 (`Workspace`/`Session`/`AuditEvent`), logo F04 primeiro evita codar contra tipo provisório. `proplan:next` aplicado à #5. A ordem completa vive no `docs/STATUS.md`. | PI (delegado) |
 | 2026-07-19 | MVP-001 Fundação estruturado como épico com **5 fatias** (uma por spec), substituindo a "fatia única com 5 specs" do plano original | PI |
 | 2026-07-19 | `CONVENTION.md` cobre processo (labels `proplan:*`) **e** contrato de dados das entidades | PI |
 | 2026-07-18 | Processo de design system formal do PRD **suspenso** para time solo + IA (Tailwind + Radix ad-hoc, tokens mínimos) | PI (via plano de fundação) |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -40,7 +40,7 @@ Status: **em andamento** (`proplan:doing`) — spec `aprovada-pi` (2026-07-21, e
 - [x] Categorias `integracao/ai/agent/db/auth/ipc/ui/sistema`; contrato in/out definido mesmo sem fluxo p/ ai/agent/integração
 - [x] Regra "todo método loga" aplicada aos fluxos que já existem (`ipc`, `sistema`, `ui`); tag `workspace` (NOA/JARVIS/sistema). `auth` (F03), `db` (F04) e workspace-switch (F02) instrumentam nas próprias fatias — **emenda do PI de 2026-07-22**
 - [x] Fronteira log ≠ AuditEvent respeitada (stores separados; AuditEvent nasce na F04); testes de retenção-poda e redaction
-- [ ] Entrega: PR `refs #8`; docs/ commitados
+- [x] Entrega: PR [#27](https://github.com/RodReis/rrb-jarvisOS/pull/27) (`refs #8`); docs/ commitados; relatório carimbado (Regras 49, Banco 8, Tela 13)
 
 **Decisões técnicas desta fatia** (nenhuma altera escopo; registradas para não serem re-litigadas):
 
@@ -165,3 +165,4 @@ Ordem: MVP-002 (fundação de execução) → **MVP-003** ([#10](https://github.
 | Data | Fatia | PR | Observação |
 |---|---|---|---|
 | 2026-07-22 | MVP-001 · F01 Bootstrap e estrutura (#2) | [#25](https://github.com/RodReis/rrb-jarvisOS/pull/25) | CI verde na 1ª execução. Relatório ADR-003 ativo: selfcheck 10/10, guarda anti-drift verificada nos dois sentidos. Regras 14 (85%), Tela 4 (100%), Banco 0 (F04). |
+| 2026-07-22 | MVP-001 · F06 Observabilidade e Logging (#8) | [#27](https://github.com/RodReis/rrb-jarvisOS/pull/27) | Regras 49 (87.2%), **Banco 8 (85.5%)**, Tela 13 (97.6%). A categoria **Banco deixa de estar vazia antes da F04**: os testes de integração do logger tocam disco real (arquivo temporário, teardown por teste), que é exatamente o que a categoria mede — o `TESTING.md` §8 previa SQLite como primeiro caso, mas a régua é "integração com storage local", não "SQLite". Verificado também no app real: os três arquivos nascem em `userData/logs` e o registro do renderer chega ao disco. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 Regra de trabalho: **uma fatia por vez (WIP = 1)**. Só iniciar fatia com spec `aprovada-pi` e issue criada.
 
-**Ordem de execução:** 01 → **06 (logging, infra transversal)** → 02 e 04 (em paralelo) → 03 → 05. A Fatia 06 roda logo após a 01 porque 02–05 devem logar desde o início (as seções abaixo estão em ordem numérica; a 06 aparece após a 01 por ser quando ela executa).
+**Ordem de execução:** 01 → **06 (logging, infra transversal)** → 04 → 02 → 03 → 05. A Fatia 06 roda logo após a 01 porque 02–05 devem logar desde o início; a 04 vem antes da 02 porque 02/03 consomem seus contratos tipados (decisão de 2026-07-22). As seções abaixo estão em ordem numérica; a 06 aparece após a 01 por ser quando ela executa.
 
 ## MVP-001 — Fundação
 
@@ -32,15 +32,24 @@ Status: **entregue** (`proplan:done`, aguardando aceite do PI) — spec `aprovad
 
 ### Fatia 06 — Observabilidade e Logging (`docs/spec/spec-fundacao-06-observabilidade-logging.md`)
 
-Status: spec `aprovada-pi` (2026-07-21); issue **#8** em Backlog. **Roda após a 01, antes de 02–05** (infra transversal — ADR-005).
+Status: **em andamento** (`proplan:doing`) — spec `aprovada-pi` (2026-07-21, emendada em 2026-07-22); issue **#8**; branch `feat/observabilidade-logging`. **Roda após a 01, antes de 02–05** (infra transversal — ADR-005).
 
-- [ ] `electron-log` no renderer (captura + IPC) + `winston`/`daily-rotate-file` no main como **escritor único**; ponte roteando renderer→winston
-- [ ] Registro JSON estruturado (`ts/level/category/direction/workspace/msg/ctx/correlationId/…`) com `msg` em pt-BR e redaction obrigatória
-- [ ] Retenção por nível zipada e local: info 3d / warn 7d / error 10d (verificar poda dos `.gz`)
-- [ ] Categorias `integracao/ai/agent/db/auth/ipc/ui/sistema`; contrato in/out definido mesmo sem fluxo p/ ai/agent/integração
-- [ ] Regra "todo método loga" aplicada a auth/workspace-switch/db/ipc; tag `workspace` (NOA/JARVIS)
-- [ ] Fronteira log ≠ AuditEvent respeitada; testes de retenção-poda e redaction
-- [ ] Entrega: PR `refs #N`; docs/ commitados
+- [x] `electron-log` no renderer (captura + IPC) + `winston`/`daily-rotate-file` no main como **escritor único**; ponte roteando renderer→winston
+- [x] Registro JSON estruturado (`ts/level/category/direction/workspace/msg/ctx/correlationId/…`) com `msg` em pt-BR e redaction obrigatória
+- [x] Retenção por nível zipada e local: info 3d / warn 7d / error 10d (poda dos `.gz` verificada — ver decisão 3 abaixo)
+- [x] Categorias `integracao/ai/agent/db/auth/ipc/ui/sistema`; contrato in/out definido mesmo sem fluxo p/ ai/agent/integração
+- [x] Regra "todo método loga" aplicada aos fluxos que já existem (`ipc`, `sistema`, `ui`); tag `workspace` (NOA/JARVIS/sistema). `auth` (F03), `db` (F04) e workspace-switch (F02) instrumentam nas próprias fatias — **emenda do PI de 2026-07-22**
+- [x] Fronteira log ≠ AuditEvent respeitada (stores separados; AuditEvent nasce na F04); testes de retenção-poda e redaction
+- [ ] Entrega: PR `refs #8`; docs/ commitados
+
+**Decisões técnicas desta fatia** (nenhuma altera escopo; registradas para não serem re-litigadas):
+
+1. **Um arquivo por nível, com filtro de nível exato** — `level: 'info'` num transport do winston significa "info **e tudo mais severo**". Um transport por nível sem filtro colocaria os `error` também no arquivo de info, e eles seriam podados em **3 dias em vez de 10** — a retenção por nível deixaria de valer. O filtro `exactLevel` é o que faz a decisão do PI (info 3d / warn 7d / error 10d) ser verdade no disco.
+2. **Redaction em `src/shared`, aplicada nos dois lados** — é regra pura (sem Electron, sem IO), então mora junto do contrato e é testável direto. Roda no renderer (para o segredo não chegar a trafegar no IPC) e de novo no main antes de gravar. Objeto que se declara `sensitivity: credential|secret|personal|financial|health` é redigido **inteiro**: redigir só o campo `sensitivity` deixaria o valor rotulado passar.
+3. **O gotcha do `.gz` não se aplica a esta versão** — a spec (§ Observações) alerta que `winston-daily-rotate-file` poderia não podar os `.gz`, porque a poda do `file-stream-rotator` apaga `file.name`, o nome **sem** extensão de compactação. Verificado no código da versão instalada (**5.0.0**): o evento `logRemoved` apaga `params.name + '.gz'`. Há teste que prova isso na versão instalada, em vez de confiar na leitura.
+4. **Payload do IPC é validado antes de gravar** — o renderer é fronteira de confiança mesmo sendo nosso código. `parseLogInput` descarta registro que não casa com o contrato (categoria inventada, nível fora da lista) e **não** deixa o renderer forjar `source`. Descartar é deliberado: gravar registro malformado polui a evidência.
+5. **Console de dev decidido por `app.isPackaged`, não `NODE_ENV`** — no app empacotado a variável costuma vir vazia, e o console ficaria ligado em produção. Mesma lição da decisão 3 da Fatia 01. O sinal entra como parâmetro de `initLogger`, o que mantém o módulo testável sem carregar o Electron.
+6. **`fileParallelism: false` na categoria Banco** — testes de integração tocam disco e o logger é um singleton de processo; em paralelo, um arquivo derruba o outro. Serial é o que torna a categoria determinística.
 
 ### Fatia 02 — AppShell e WorkspaceSwitcher (`docs/spec/spec-fundacao-02-appshell-workspaces.md`)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -66,7 +66,7 @@ Não há catálogo numérico `SPEC-nnn` para o MVP-001: as specs são identifica
 
 ## Próximas ações
 
-1. ~~**Code**: mover a Fatia 01 (#2) para A Fazer → Em Andamento e iniciar~~ — **em andamento** (2026-07-22): #2 em `proplan:doing`, branch `feat/bootstrap`, critérios de aceite verificados, PR aberto. Próxima da fila: Fatia 06 (#8). Ordem: 01 → 06 (#8) → 02/04 → 03 → 05.
+1. **Fila do MVP-001** (2026-07-22): F01 (#2) entregue → **F06 (#8) em andamento** (`proplan:doing`). Cabeça da fila marcada com `proplan:next` = **F04 (#5)**. Ordem: **01 → 06 (#8) → 04 (#5) → 02 (#3) → 03 (#4) → 05 (#6)** — F04 antes de F02 porque 02/03 consomem seus contratos tipados (decisão do PI delegada ao Cowork, 2026-07-22).
 2. ~~Resolver as "Perguntas ao PI" das specs do MVP-003~~ — **feito** (2026-07-21): as 8 specs estão `aprovada-pi`.
 3. ~~Renumerar #10 → MVP-004 e criar o épico MVP-003 + issues~~ — **feito** (2026-07-21): #10 retitulada MVP-004 (carimbo), épico **#16** criado, 8 filhas **#17–#24** em Backlog e vinculadas.
 4. **Code**: quando MVP-001/002 estiverem entregues, iniciar o MVP-003 pela F01 (#17); WIP = 1, na ordem F01 → F02 → (F03a/F03b/F05) → F04a → F04b → F06.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -12,14 +12,21 @@ Atualizado em: **2026-07-22**. Mantido pelo Code a cada entrega (junto com `DEVE
 | [#4](https://github.com/RodReis/rrb-jarvisOS/issues/4) | 03 Auth Google local-first | MVP-001 (#1) | `spec-fundacao-03-auth-google.md` | F03 |
 | [#5](https://github.com/RodReis/rrb-jarvisOS/issues/5) | 04 Dados mínimos + AuditEvent | MVP-001 (#1) | `spec-fundacao-04-dados-audit.md` | F04 |
 | [#6](https://github.com/RodReis/rrb-jarvisOS/issues/6) | 05 Settings mínimo | MVP-001 (#1) | `spec-fundacao-05-settings.md` | F05 |
-| [#8](https://github.com/RodReis/rrb-jarvisOS/issues/8) | 06 Observabilidade e Logging | MVP-001 (#1) | `spec-fundacao-06-observabilidade-logging.md` | F06 |
 | [#11](https://github.com/RodReis/rrb-jarvisOS/issues/11) | 02 Policy Engine mínimo (classificação) | MVP-002 (#9) | `spec-execucao-local-02-policy-engine.md` | M2-F02 |
 | [#12](https://github.com/RodReis/rrb-jarvisOS/issues/12) | 03 Diretórios permitidos (allowlist) | MVP-002 (#9) | `spec-execucao-local-03-allowlist-diretorios.md` | M2-F03 |
 | [#13](https://github.com/RodReis/rrb-jarvisOS/issues/13) | 04 Registro de workflows + automações | MVP-002 (#9) | `spec-execucao-local-04-registro-workflows.md` | M2-F04 |
 | [#14](https://github.com/RodReis/rrb-jarvisOS/issues/14) | 05 Motor de execução simulado | MVP-002 (#9) | `spec-execucao-local-05-execucao-simulada.md` | M2-F05 |
 | [#15](https://github.com/RodReis/rrb-jarvisOS/issues/15) | 01 Supabase local + ambiente de sync | MVP-002 (#9) | `spec-execucao-local-01-supabase-local.md` | M2-F01 |
 
-> A Fatia 06 saiu como **#8** (o número 7 já estava ocupado). Sub-issue do épico #1; label `proplan:backlog`, assignee PI.
+> **`proplan:next`** (cabeça da fila) está em **[#5](https://github.com/RodReis/rrb-jarvisOS/issues/5) — F04**, não na #3: 02/03 consomem os contratos tipados da 04 (decisão de 2026-07-22, `DECISIONS.md`).
+
+### Em Andamento (`proplan:doing`)
+
+| Issue | Fatia | MVP | Spec | Índice | Branch |
+|---|---|---|---|---|---|
+| [#8](https://github.com/RodReis/rrb-jarvisOS/issues/8) | 06 Observabilidade e Logging | MVP-001 (#1) | `spec-fundacao-06-observabilidade-logging.md` | F06 | `feat/observabilidade-logging` |
+
+> A Fatia 06 saiu como **#8** (o número 7 já estava ocupado). Sub-issue do épico #1; assignee PI.
 
 ### Feito (`proplan:done` — entregue, aguardando aceite do PI)
 
@@ -27,7 +34,7 @@ Atualizado em: **2026-07-22**. Mantido pelo Code a cada entrega (junto com `DEVE
 |---|---|---|---|---|---|
 | [#2](https://github.com/RodReis/rrb-jarvisOS/issues/2) | 01 Bootstrap e estrutura | MVP-001 (#1) | `spec-fundacao-01-bootstrap.md` | F01 | [#25](https://github.com/RodReis/rrb-jarvisOS/pull/25) |
 
-### A Fazer · Em Andamento · Finalizado
+### A Fazer · Finalizado
 
 *(vazios)*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "rrb-jarvisos",
       "version": "0.1.0",
       "license": "UNLICENSED",
+      "dependencies": {
+        "electron-log": "^5.4.4",
+        "winston": "^3.19.0",
+        "winston-daily-rotate-file": "^5.0.0"
+      },
       "devDependencies": {
         "@electron-toolkit/tsconfig": "^2.0.0",
         "@eslint/js": "^9.39.5",
@@ -444,6 +449,15 @@
         "specificity": "bin/cli.js"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
@@ -582,6 +596,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@electron-internal/extract-zip": {
@@ -1767,6 +1792,16 @@
         "win32"
       ]
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2260,6 +2295,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
@@ -2843,6 +2884,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2986,6 +3033,19 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3005,6 +3065,48 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3181,6 +3283,15 @@
         "node": ">= 22.12.0"
       }
     },
+    "node_modules/electron-log": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.4.tgz",
+      "integrity": "sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.395",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
@@ -3233,6 +3344,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -3596,6 +3713,12 @@
         }
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3607,6 +3730,15 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.1"
       }
     },
     "node_modules/find-up": {
@@ -3646,6 +3778,12 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3827,6 +3965,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3856,6 +4000,18 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4040,6 +4196,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -4351,6 +4513,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4452,11 +4631,19 @@
         "node": "*"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4495,6 +4682,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -4507,6 +4703,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/optionator": {
@@ -4775,6 +4980,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -4854,6 +5073,35 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -4924,6 +5172,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -4937,6 +5194,15 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -5017,6 +5283,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5106,6 +5378,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5229,6 +5510,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.6",
@@ -5958,6 +6245,60 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-daily-rotate-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
+      "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^3.0.0",
+        "triple-beam": "^1.4.1",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "winston": "^3"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -51,5 +51,10 @@
     "typescript-eslint": "^8.46.4",
     "vite": "^7.3.6",
     "vitest": "^4.1.10"
+  },
+  "dependencies": {
+    "electron-log": "^5.4.4",
+    "winston": "^3.19.0",
+    "winston-daily-rotate-file": "^5.0.0"
   }
 }

--- a/reports/TESTS.md
+++ b/reports/TESTS.md
@@ -12,9 +12,9 @@ Totais da última execução (regenerado, não acumulado):
 
 | Data | Issue | SPEC | Categoria | Testes | Pass | Falha | Cobertura % | PR | Link PR |
 |------|-------|------|-----------|-------:|-----:|------:|------------:|----:|--------|
-| — | — | — | Regras de Negócio | 14 | 14 | 0 | 85.0 | — | — |
-| — | — | — | Banco | 0 | 0 | 0 | — | — | — |
-| — | — | — | Tela | 4 | 4 | 0 | 100.0 | — | — |
+| — | — | — | Regras de Negócio | 49 | 49 | 0 | 87.2 | — | — |
+| — | — | — | Banco | 8 | 8 | 0 | 85.5 | — | — |
+| — | — | — | Tela | 13 | 13 | 0 | 97.6 | — | — |
 
 ## Histórico por entrega
 
@@ -25,3 +25,6 @@ Append-only — linhas de entregas passadas são imutáveis.
 | 2026-07-21 | #2 | spec-fundacao-01-bootstrap | Regras de Negócio | 14 | 14 | 0 | 85.0 | #25 | [#25](https://github.com/RodReis/rrb-jarvisOS/pull/25) |
 | 2026-07-21 | #2 | spec-fundacao-01-bootstrap | Banco | 0 | 0 | 0 | — | #25 | [#25](https://github.com/RodReis/rrb-jarvisOS/pull/25) |
 | 2026-07-21 | #2 | spec-fundacao-01-bootstrap | Tela | 4 | 4 | 0 | 100.0 | #25 | [#25](https://github.com/RodReis/rrb-jarvisOS/pull/25) |
+| 2026-07-22 | #8 | spec-fundacao-06-observabilidade-logging | Regras de Negócio | 49 | 49 | 0 | 87.2 | #27 | [#27](https://github.com/RodReis/rrb-jarvisOS/pull/27) |
+| 2026-07-22 | #8 | spec-fundacao-06-observabilidade-logging | Banco | 8 | 8 | 0 | 85.5 | #27 | [#27](https://github.com/RodReis/rrb-jarvisOS/pull/27) |
+| 2026-07-22 | #8 | spec-fundacao-06-observabilidade-logging | Tela | 13 | 13 | 0 | 97.6 | #27 | [#27](https://github.com/RodReis/rrb-jarvisOS/pull/27) |

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,21 +1,52 @@
+import { join } from 'node:path'
 import { app, BrowserWindow } from 'electron'
 import { registerIpcHandlers } from './ipc/handlers'
+import { closeLogger, initLogger, log } from './logging/logger'
+import { initRendererLogBridge } from './logging/renderer-bridge'
 import { createMainWindow } from './window'
 
 app.whenReady().then(() => {
   // Agrupa a janela sob a identidade correta na barra de tarefas do Windows.
   app.setAppUserModelId('com.rodrigoreis.jarvisos')
 
+  // Logging antes de tudo: uma falha no registro dos handlers ou na criação da janela
+  // precisa aparecer no arquivo. `userData/logs` fica fora do repo (ADR-005).
+  initLogger(join(app.getPath('userData'), 'logs'), { console: !app.isPackaged })
+  initRendererLogBridge()
+  log.sistema.info('Aplicação iniciada', {
+    versao: app.getVersion(),
+    electron: process.versions.electron,
+    plataforma: process.platform
+  })
+
   registerIpcHandlers()
   createMainWindow()
 
   // macOS: recriar a janela ao clicar no dock sem janelas abertas.
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createMainWindow()
+    if (BrowserWindow.getAllWindows().length === 0) {
+      log.sistema.info('Janela recriada a partir do dock')
+      createMainWindow()
+    }
   })
 })
 
 // Tray e "fechar = minimizar" entram na Fatia 02; aqui, fechar tudo encerra o app.
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()
+})
+
+// Fecha os transports antes de sair; sem isso o último registro pode não chegar ao disco.
+app.on('will-quit', () => {
+  log.sistema.info('Aplicação encerrada')
+  closeLogger()
+})
+
+// Falha não capturada é o caso em que o log mais importa — e o que mais some sem isto.
+process.on('uncaughtException', (error) => {
+  log.sistema.error('Exceção não capturada no processo principal', { error })
+})
+
+process.on('unhandledRejection', (reason) => {
+  log.sistema.error('Promise rejeitada sem tratamento no processo principal', { reason })
 })

--- a/src/main/ipc/handlers.spec.ts
+++ b/src/main/ipc/handlers.spec.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it, vi } from 'vitest'
-import { IPC_CHANNELS } from '@shared/contracts/ipc'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { IPC_CHANNELS, IPC_SEND_CHANNELS } from '@shared/contracts/ipc'
 import { buildAppInfo, registerIpcHandlers } from './handlers'
 
 const handle = vi.fn()
+const on = vi.fn()
+const writeLog = vi.fn()
 
 vi.mock('electron', () => ({
   app: {
@@ -11,9 +13,35 @@ vi.mock('electron', () => ({
     isPackaged: false
   },
   ipcMain: {
-    handle: (...args: unknown[]) => handle(...args)
+    handle: (...args: unknown[]) => handle(...args),
+    on: (...args: unknown[]) => on(...args)
   }
 }))
+
+// O logger real abriria arquivos em disco; aqui interessa *o que* seria gravado.
+vi.mock('../logging/logger', () => {
+  const categoria = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  return {
+    log: new Proxy({}, { get: () => categoria }),
+    writeLog: (...args: unknown[]) => writeLog(...args)
+  }
+})
+
+/** Executa o ouvinte registrado no canal de log, como o Electron faria. */
+function emitirLogDoRenderer(payload: unknown): void {
+  registerIpcHandlers()
+  const ouvinte = on.mock.calls.find(([canal]) => canal === IPC_SEND_CHANNELS.log)?.[1] as (
+    evento: unknown,
+    payload: unknown
+  ) => void
+  ouvinte({}, payload)
+}
+
+beforeEach(() => {
+  handle.mockClear()
+  on.mockClear()
+  writeLog.mockClear()
+})
 
 describe('buildAppInfo', () => {
   it('devolve apenas os campos públicos do contrato', () => {
@@ -27,11 +55,44 @@ describe('buildAppInfo', () => {
 })
 
 describe('registerIpcHandlers', () => {
-  it('registra um handler para cada canal do contrato, e só para eles', () => {
-    handle.mockClear()
+  it('registra um handler para cada canal de request/response, e só para eles', () => {
     registerIpcHandlers()
 
     const registrados = handle.mock.calls.map(([canal]) => canal).sort()
     expect(registrados).toEqual(Object.values(IPC_CHANNELS).sort())
+  })
+
+  it('registra um ouvinte para cada canal só de ida, e só para eles', () => {
+    registerIpcHandlers()
+
+    const registrados = on.mock.calls.map(([canal]) => canal).sort()
+    expect(registrados).toEqual(Object.values(IPC_SEND_CHANNELS).sort())
+  })
+})
+
+describe('canal de log do renderer', () => {
+  it('grava o registro marcando a origem como renderer', () => {
+    emitirLogDoRenderer({ level: 'info', category: 'ui', msg: 'Tela carregada' })
+
+    expect(writeLog).toHaveBeenCalledWith({
+      level: 'info',
+      category: 'ui',
+      msg: 'Tela carregada',
+      source: 'renderer'
+    })
+  })
+
+  it('descarta payload que não casa com o contrato em vez de gravar', () => {
+    // O IPC é fronteira de confiança: categoria inventada viraria arquivo com categoria
+    // fora do contrato. Descartar é deliberado — não se "conserta" registro malformado.
+    emitirLogDoRenderer({ level: 'info', category: 'financeiro', msg: 'x' })
+
+    expect(writeLog).not.toHaveBeenCalled()
+  })
+
+  it('não deixa o renderer forjar a origem do registro', () => {
+    emitirLogDoRenderer({ level: 'info', category: 'ui', msg: 'x', source: 'main' })
+
+    expect(writeLog).toHaveBeenCalledWith(expect.objectContaining({ source: 'renderer' }))
   })
 })

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1,5 +1,7 @@
 import { app, ipcMain } from 'electron'
-import { IPC_CHANNELS, type AppInfo } from '@shared/contracts/ipc'
+import { IPC_CHANNELS, IPC_SEND_CHANNELS, type AppInfo } from '@shared/contracts/ipc'
+import { parseLogInput } from '@shared/contracts/logging-input'
+import { log, writeLog } from '../logging/logger'
 
 /** Monta o payload público do app. Sem segredo, sem caminho de disco, sem env cru. */
 export function buildAppInfo(): AppInfo {
@@ -12,9 +14,42 @@ export function buildAppInfo(): AppInfo {
 }
 
 /**
- * Registra os handlers dos canais declarados em `IPC_CHANNELS`.
+ * Registra os handlers dos canais declarados em `IPC_CHANNELS` e `IPC_SEND_CHANNELS`.
  * Cada canal do contrato tem exatamente um handler aqui — não há rota genérica.
+ *
+ * A regra "todo método loga" (CONVENTION §3) vale aqui: cada canal emite `info` no fluxo
+ * normal e `error` na falha, com `direction` marcando a entrada e a saída da chamada.
  */
 export function registerIpcHandlers(): void {
-  ipcMain.handle(IPC_CHANNELS.appInfo, () => buildAppInfo())
+  ipcMain.handle(IPC_CHANNELS.appInfo, () => {
+    log.ipc.info('Metadados do app solicitados', { canal: IPC_CHANNELS.appInfo, direction: 'in' })
+
+    try {
+      const info = buildAppInfo()
+      log.ipc.info('Metadados do app devolvidos', {
+        canal: IPC_CHANNELS.appInfo,
+        direction: 'out',
+        ambiente: info.environment
+      })
+      return info
+    } catch (error) {
+      log.ipc.error('Falha ao montar metadados do app', { canal: IPC_CHANNELS.appInfo, error })
+      throw error
+    }
+  })
+
+  // Só de ida: o renderer manda o registro, o main grava. Sem resposta de propósito —
+  // esperar confirmação de log tornaria a UI refém do disco.
+  ipcMain.on(IPC_SEND_CHANNELS.log, (_event, payload: unknown) => {
+    const input = parseLogInput(payload)
+
+    if (!input) {
+      log.ipc.warn('Registro de log do renderer descartado por não casar com o contrato', {
+        canal: IPC_SEND_CHANNELS.log
+      })
+      return
+    }
+
+    writeLog({ ...input, source: 'renderer' })
+  })
 }

--- a/src/main/logging/logger.int-spec.ts
+++ b/src/main/logging/logger.int-spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Integração do logger com o disco (categoria "Banco" do ADR-003).
+ *
+ * O que se prova aqui não dá para provar em unidade: que o arquivo escrito **não contém** o
+ * segredo, que cada nível vai para o seu próprio arquivo (a retenção é por nível) e que a
+ * poda apaga também o `.gz`. É a diferença entre "a função redige" e "o disco está limpo".
+ */
+
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { LogRecord } from '@shared/contracts/logging'
+import { closeLogger, initLogger, log, setCurrentWorkspace, writeLog } from './logger'
+
+let logsDir: string
+
+/** Winston escreve de forma assíncrona; o teste espera o arquivo aparecer em vez de dormir. */
+async function aguardarArquivos(prefixo: string, tentativas = 50): Promise<string[]> {
+  for (let i = 0; i < tentativas; i += 1) {
+    const encontrados = readdirSync(logsDir).filter((nome) => nome.startsWith(prefixo))
+    if (encontrados.length > 0) return encontrados
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  return []
+}
+
+async function lerRegistros(prefixo: string): Promise<LogRecord[]> {
+  const arquivos = await aguardarArquivos(prefixo)
+
+  return arquivos.flatMap((nome) =>
+    readFileSync(join(logsDir, nome), 'utf8')
+      .split('\n')
+      .filter((linha) => linha.trim().length > 0)
+      .map((linha) => JSON.parse(linha) as LogRecord)
+  )
+}
+
+beforeEach(() => {
+  logsDir = mkdtempSync(join(tmpdir(), 'jarvis-logs-'))
+  initLogger(logsDir)
+})
+
+afterEach(async () => {
+  closeLogger()
+  // O winston fecha os streams de forma assíncrona: apagar o diretório em seguida faz o
+  // flush pendente falhar com ENOENT e derruba o teste vizinho. Espera-se o fechamento.
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  rmSync(logsDir, { recursive: true, force: true })
+})
+
+describe('logger do main', () => {
+  it('grava registro JSON com os campos mínimos do contrato', async () => {
+    log.ipc.info('Metadados do app solicitados', { canal: 'app:info' })
+
+    const [registro] = await lerRegistros('info-')
+
+    expect(registro).toMatchObject({
+      level: 'info',
+      category: 'ipc',
+      msg: 'Metadados do app solicitados',
+      source: 'main',
+      workspace: 'sistema',
+      pid: process.pid
+    })
+    expect(registro?.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(registro?.ctx).toEqual({ canal: 'app:info' })
+  })
+
+  it('não grava o valor de campo sensível no arquivo', async () => {
+    // A prova é sobre o **arquivo**, não sobre a função: o critério de aceite 4 da spec
+    // exige que o token não esteja no disco.
+    log.auth.info('Login Google concluído', {
+      userId: 'u-1',
+      accessToken: 'ya29.token-secreto-que-nao-pode-vazar'
+    })
+
+    const arquivos = await aguardarArquivos('info-')
+    const conteudo = arquivos.map((nome) => readFileSync(join(logsDir, nome), 'utf8')).join('')
+
+    expect(conteudo).not.toContain('ya29.token-secreto-que-nao-pode-vazar')
+    expect(conteudo).toContain('[redigido]')
+    expect(conteudo).toContain('u-1')
+  })
+
+  it('separa os níveis em arquivos distintos, sem transbordo do mais severo', async () => {
+    // `level: 'info'` no winston significa "info e tudo mais severo". Sem o filtro de nível
+    // exato, os `error` cairiam também no arquivo de info e seriam podados em 3 dias em vez
+    // de 10 — a retenção por nível deixaria de valer.
+    log.sistema.info('Aplicação iniciada')
+    log.sistema.warn('Degradação recuperável')
+    log.sistema.error('Falha ao gravar')
+
+    const info = await lerRegistros('info-')
+    const warn = await lerRegistros('warn-')
+    const error = await lerRegistros('error-')
+
+    expect(info.map((r) => r.level)).toEqual(['info'])
+    expect(warn.map((r) => r.level)).toEqual(['warn'])
+    expect(error.map((r) => r.level)).toEqual(['error'])
+  })
+
+  it('etiqueta o registro com o workspace ativo', async () => {
+    setCurrentWorkspace('noa')
+    log.ui.info('Tela aberta')
+
+    const [registro] = await lerRegistros('info-')
+
+    expect(registro?.workspace).toBe('noa')
+    setCurrentWorkspace('sistema')
+  })
+
+  it('marca como renderer o registro que chega pela ponte', async () => {
+    writeLog({ level: 'info', category: 'ui', msg: 'Componente montado', source: 'renderer' })
+
+    const [registro] = await lerRegistros('info-')
+
+    expect(registro?.source).toBe('renderer')
+  })
+
+  it('preserva direction e correlationId para casar entrada e saída', async () => {
+    writeLog({
+      level: 'info',
+      category: 'integracao',
+      msg: 'Resposta da API recebida',
+      direction: 'in',
+      correlationId: 'op-42',
+      source: 'main'
+    })
+
+    const [registro] = await lerRegistros('info-')
+
+    expect(registro?.direction).toBe('in')
+    expect(registro?.correlationId).toBe('op-42')
+  })
+})
+
+describe('retenção por nível', () => {
+  it('configura maxFiles em dias conforme a decisão do PI (info 3 / warn 7 / error 10)', () => {
+    // A janela real (3, 7 e 10 dias) não é observável num teste: exigiria adiantar o relógio
+    // por dias. O que se prova aqui é que o transport recebeu a janela certa, e o teste
+    // seguinte prova que a poda apaga o `.gz` quando ela dispara.
+    const logger = initLogger(logsDir)
+    const janelas = logger.transports
+      .filter((t) => 'filename' in t)
+      .map((t) => {
+        const transport = t as unknown as { filename: string; options: { maxFiles: string } }
+        return [transport.filename.split('-%DATE%')[0], transport.options.maxFiles]
+      })
+
+    expect(Object.fromEntries(janelas)).toEqual({ info: '3d', warn: '7d', error: '10d' })
+  })
+
+  it('apaga o .gz junto do arquivo podado', async () => {
+    // Gotcha registrado na spec: a poda do file-stream-rotator apaga `file.name`, que é o
+    // nome sem `.gz`. O winston-daily-rotate-file@5 cobre isso no evento `logRemoved` —
+    // este teste é o que prova que a versão instalada de fato cobre, em vez de assumir.
+    const logger = initLogger(logsDir)
+    const transport = logger.transports.find((t) => 'filename' in t) as unknown as {
+      on(evento: string, ouvinte: (arquivo: string) => void): void
+      logStream: { emit(evento: string, params: unknown): void }
+    }
+
+    const podado = join(logsDir, 'info-2020-01-01.log')
+    writeFileSync(podado, '{}\n')
+    writeFileSync(`${podado}.gz`, '')
+
+    const removidos: string[] = []
+    transport.on('logRemoved', (arquivo) => removidos.push(arquivo))
+    transport.logStream.emit('logRemoved', { name: podado })
+
+    expect(removidos).toEqual([`${podado}.gz`])
+    expect(readdirSync(logsDir)).not.toContain('info-2020-01-01.log.gz')
+  })
+})

--- a/src/main/logging/logger.ts
+++ b/src/main/logging/logger.ts
@@ -1,0 +1,160 @@
+/**
+ * Logger do main — o **escritor único** dos arquivos (SPEC-Fundacao-06, ADR-005).
+ *
+ * O renderer nunca toca no disco: ele captura com `electron-log` e encaminha por IPC, e o
+ * que chega aqui é gravado por este winston. Dois donos do mesmo arquivo dariam rotação
+ * corrompida — daí "escritor único" ser regra, não preferência.
+ */
+
+import { mkdirSync } from 'node:fs'
+import winston from 'winston'
+import DailyRotateFile from 'winston-daily-rotate-file'
+import {
+  LOG_CATEGORIES,
+  LOG_LEVELS,
+  LOG_RETENTION_DAYS,
+  type CategoryLogger,
+  type LogCategory,
+  type LogInput,
+  type LogLevel,
+  type LogRecord
+} from '@shared/contracts/logging'
+import { redactContext } from '@shared/contracts/logging-redaction'
+
+/** Espaço ativo. A Fatia 02 (WorkspaceSwitcher) passa a atualizar isto na troca. */
+let currentWorkspace: LogRecord['workspace'] = 'sistema'
+
+export function setCurrentWorkspace(workspace: LogRecord['workspace']): void {
+  currentWorkspace = workspace
+}
+
+export function getCurrentWorkspace(): LogRecord['workspace'] {
+  return currentWorkspace
+}
+
+/**
+ * Um arquivo por nível, porque a retenção é por nível (info 3d / warn 7d / error 10d).
+ *
+ * `level: 'info'` num transport do winston significa "info **e tudo mais severo**", então um
+ * único transport por nível colocaria os `error` também no arquivo de info — e eles seriam
+ * podados em 3 dias em vez de 10. O filtro abaixo restringe cada transport ao seu nível exato.
+ */
+function exactLevel(level: LogLevel): winston.Logform.Format {
+  return winston.format((info) => (info.level === level ? info : false))()
+}
+
+/** Formato de arquivo: JSON puro, uma linha por registro, já redigido. */
+const fileFormat = winston.format.combine(
+  winston.format((info) => {
+    const record = info as unknown as LogRecord
+    return {
+      ...record,
+      ctx: redactContext(record.ctx ?? {})
+    } as unknown as winston.Logform.TransformableInfo
+  })(),
+  winston.format.json()
+)
+
+function buildTransport(level: LogLevel, dirname: string): DailyRotateFile {
+  return new DailyRotateFile({
+    dirname,
+    filename: `${level}-%DATE%.log`,
+    datePattern: 'YYYY-MM-DD',
+    // `maxFiles` com sufixo `d` é retenção em dias; sem o sufixo seria contagem de arquivos.
+    maxFiles: `${LOG_RETENTION_DAYS[level]}d`,
+    zippedArchive: true,
+    level,
+    format: winston.format.combine(exactLevel(level), fileFormat)
+  })
+}
+
+let logger: winston.Logger | undefined
+
+/**
+ * Cria o logger e os arquivos em `logsDir` (em produção, `userData/logs` — fora do repo).
+ * Idempotente: chamar de novo devolve a instância existente, para não empilhar transports.
+ *
+ * `console` liga o transport legível de dev. Quem chama passa `!app.isPackaged`, e não
+ * `NODE_ENV`: no app empacotado a variável costuma vir vazia, e o console ficaria ligado em
+ * produção. É a mesma lição da Fatia 01 — o sinal confiável no Electron é `app.isPackaged`.
+ * O parâmetro mantém este módulo testável sem carregar o Electron.
+ */
+export function initLogger(logsDir: string, { console = false } = {}): winston.Logger {
+  if (logger) return logger
+
+  mkdirSync(logsDir, { recursive: true })
+
+  logger = winston.createLogger({
+    level: 'info',
+    transports: LOG_LEVELS.map((level) => buildTransport(level, logsDir))
+  })
+
+  if (console) {
+    logger.add(
+      new winston.transports.Console({
+        level: 'debug',
+        format: winston.format.combine(
+          winston.format(
+            (info) =>
+              ({
+                ...info,
+                ctx: redactContext((info as unknown as LogRecord).ctx ?? {})
+              }) as unknown as winston.Logform.TransformableInfo
+          )(),
+          winston.format.printf((info) => {
+            const record = info as unknown as LogRecord
+            const ctx =
+              Object.keys(record.ctx ?? {}).length > 0 ? ` ${JSON.stringify(record.ctx)}` : ''
+            return `[${record.level}] ${record.category} · ${record.msg}${ctx}`
+          })
+        )
+      })
+    )
+  }
+
+  return logger
+}
+
+/** Grava um registro já completo. É por aqui que a ponte do renderer entra. */
+export function writeLog(input: LogInput & { readonly source: LogRecord['source'] }): void {
+  if (!logger) return
+
+  const record: LogRecord = {
+    ts: new Date().toISOString(),
+    level: input.level,
+    category: input.category,
+    ...(input.direction ? { direction: input.direction } : {}),
+    workspace: input.workspace ?? currentWorkspace,
+    msg: input.msg,
+    ctx: input.ctx ?? {},
+    ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+    pid: process.pid,
+    source: input.source
+  }
+
+  logger.log(record as unknown as winston.LogEntry)
+}
+
+function categoryLogger(category: LogCategory): CategoryLogger {
+  const emit =
+    (level: LogLevel) =>
+    (msg: string, ctx?: LogRecord['ctx']): void =>
+      writeLog({ level, category, msg, ...(ctx ? { ctx } : {}), source: 'main' })
+
+  return { error: emit('error'), warn: emit('warn'), info: emit('info') }
+}
+
+/**
+ * Um child logger por categoria: `log.ipc.info('...')` no call site, sem repetir a categoria.
+ * Todas as categorias do contrato existem aqui, inclusive as que ainda não têm fluxo
+ * (`ai`, `agent`, `integracao`) — é o que garante assinatura idêntica quando elas nascerem.
+ */
+export const log = Object.fromEntries(
+  LOG_CATEGORIES.map((category) => [category, categoryLogger(category)])
+) as Readonly<Record<LogCategory, CategoryLogger>>
+
+/** Fecha os transports. Usado no encerramento do app e no teardown dos testes. */
+export function closeLogger(): void {
+  logger?.close()
+  logger = undefined
+}

--- a/src/main/logging/renderer-bridge.ts
+++ b/src/main/logging/renderer-bridge.ts
@@ -1,0 +1,59 @@
+/**
+ * Ponte renderer → main para logs (SPEC-Fundacao-06, ADR-005).
+ *
+ * O renderer captura com `electron-log` e encaminha; aqui o registro é repassado ao winston,
+ * que é o **escritor único**. Por isso os transports de arquivo do próprio `electron-log`
+ * ficam desligados: dois donos do mesmo arquivo quebrariam a rotação.
+ *
+ * Há dois caminhos de entrada, de propósito:
+ *  - `window.jarvis.sendLog(...)` — chamada explícita e tipada, o caminho normal do nosso código;
+ *  - `electron-log` — pega o que passa por `console.*` do renderer, inclusive de dependências,
+ *    que nunca conheceriam a nossa ponte.
+ */
+
+import electronLog from 'electron-log/main'
+import type { LogCategory, LogLevel } from '@shared/contracts/logging'
+import { writeLog } from './logger'
+
+/** `electron-log` tem níveis que o contrato não grava; mapeiam para o mais próximo. */
+function toContractLevel(level: string): LogLevel | undefined {
+  if (level === 'error') return 'error'
+  if (level === 'warn') return 'warn'
+  if (level === 'info' || level === 'verbose' || level === 'debug' || level === 'silly') {
+    return 'info'
+  }
+  return undefined
+}
+
+export function initRendererLogBridge(): void {
+  // Arquivo desligado: quem grava é o winston. Não é otimização — é a regra do escritor único.
+  electronLog.transports.file.level = false
+  electronLog.transports.console.level = false
+
+  const winstonTransport = (message: { level: string; data: unknown[] }): void => {
+    const level = toContractLevel(message.level)
+    if (!level) return
+
+    const [first, ...rest] = message.data
+    const msg = typeof first === 'string' ? first : JSON.stringify(first)
+
+    writeLog({
+      level,
+      // Vindo do console do renderer, a origem é a UI — a categoria segue isso.
+      category: 'ui' satisfies LogCategory,
+      msg,
+      ...(rest.length > 0 ? { ctx: { detalhes: rest } } : {}),
+      source: 'renderer'
+    })
+  }
+
+  // `level`/`transforms` são o formato de transport que o electron-log espera; sem eles ele
+  // ignora o transport em silêncio. `transforms: []` = nada a transformar antes de repassar.
+  winstonTransport.level = 'silly' as const
+  winstonTransport.transforms = []
+
+  electronLog.transports['winston'] = winstonTransport as never
+
+  // Injeta o bridge do electron-log nas sessões, para capturar `console.*` do renderer.
+  electronLog.initialize({ spyRendererConsole: true })
+}

--- a/src/main/preload/index.ts
+++ b/src/main/preload/index.ts
@@ -1,5 +1,12 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import { BRIDGE_KEY, IPC_CHANNELS, type AppInfo, type JarvisBridge } from '@shared/contracts/ipc'
+import {
+  BRIDGE_KEY,
+  IPC_CHANNELS,
+  IPC_SEND_CHANNELS,
+  type AppInfo,
+  type JarvisBridge
+} from '@shared/contracts/ipc'
+import type { LogInput } from '@shared/contracts/logging'
 
 /**
  * Preload — a ponte tipada e o único ponto de contato do renderer com o main.
@@ -9,7 +16,10 @@ import { BRIDGE_KEY, IPC_CHANNELS, type AppInfo, type JarvisBridge } from '@shar
  * anularia a fronteira de segurança (docs/ARCHITECTURE.md).
  */
 const bridge: JarvisBridge = {
-  getAppInfo: (): Promise<AppInfo> => ipcRenderer.invoke(IPC_CHANNELS.appInfo)
+  getAppInfo: (): Promise<AppInfo> => ipcRenderer.invoke(IPC_CHANNELS.appInfo),
+  // `send`, não `invoke`: o renderer não espera confirmação de gravação (ADR-005 — quem
+  // escreve é o main). Aguardar o disco para logar prenderia a UI ao IO.
+  sendLog: (record: LogInput): void => ipcRenderer.send(IPC_SEND_CHANNELS.log, record)
 }
 
 if (process.contextIsolated) {

--- a/src/main/preload/preload.spec.ts
+++ b/src/main/preload/preload.spec.ts
@@ -1,15 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { BRIDGE_KEY, IPC_CHANNELS } from '@shared/contracts/ipc'
+import { BRIDGE_KEY, IPC_CHANNELS, IPC_SEND_CHANNELS } from '@shared/contracts/ipc'
 
 const exposeInMainWorld = vi.fn()
 const invoke = vi.fn().mockResolvedValue({})
+const send = vi.fn()
 
 vi.mock('electron', () => ({
   contextBridge: {
     exposeInMainWorld: (...args: unknown[]) => exposeInMainWorld(...args)
   },
   ipcRenderer: {
-    invoke: (...args: unknown[]) => invoke(...args)
+    invoke: (...args: unknown[]) => invoke(...args),
+    send: (...args: unknown[]) => send(...args)
   }
 }))
 
@@ -39,7 +41,7 @@ describe('ponte do preload', () => {
     const bridge = await carregarPonte()
     // Critério de aceite 4: a superfície é fechada. Um `invoke`/`send`/`on` cru aqui
     // deixaria o renderer alcançar qualquer handler do main.
-    expect(Object.keys(bridge).sort()).toEqual(['getAppInfo'])
+    expect(Object.keys(bridge).sort()).toEqual(['getAppInfo', 'sendLog'])
   })
 
   it('não expõe ipcRenderer nem primitivas de canal arbitrário', async () => {
@@ -53,6 +55,18 @@ describe('ponte do preload', () => {
     const bridge = await carregarPonte()
     await (bridge.getAppInfo as () => Promise<unknown>)()
     expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.appInfo)
+  })
+
+  it('roteia sendLog pelo canal de ida, sem esperar resposta', async () => {
+    // `send`, não `invoke`: o renderer não pode ficar esperando o disco para logar.
+    const bridge = await carregarPonte()
+    const registro = { level: 'info', category: 'ui', msg: 'Tela carregada' }
+
+    const retorno = (bridge.sendLog as (r: unknown) => unknown)(registro)
+
+    expect(send).toHaveBeenCalledWith(IPC_SEND_CHANNELS.log, registro)
+    expect(invoke).not.toHaveBeenCalled()
+    expect(retorno).toBeUndefined()
   })
 
   it('recusa expor a ponte quando contextIsolation está desligado', async () => {

--- a/src/renderer/src/app/App.test.tsx
+++ b/src/renderer/src/app/App.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AppInfo } from '@shared/contracts/ipc'
 import { App } from './App'
 
@@ -10,9 +10,11 @@ const appInfo: AppInfo = {
   environment: 'development'
 }
 
+const sendLog = vi.fn()
+
 function mockarPonte(getAppInfo: () => Promise<AppInfo>): void {
   Object.defineProperty(window, 'jarvis', {
-    value: { getAppInfo },
+    value: { getAppInfo, sendLog },
     configurable: true,
     writable: true
   })
@@ -20,6 +22,7 @@ function mockarPonte(getAppInfo: () => Promise<AppInfo>): void {
 
 describe('App', () => {
   beforeEach(() => {
+    sendLog.mockClear()
     mockarPonte(() => Promise.resolve(appInfo))
   })
 
@@ -47,6 +50,25 @@ describe('App', () => {
     render(<App />)
     expect(await screen.findByRole('alert')).toHaveTextContent(
       'Não foi possível carregar as informações do app.'
+    )
+  })
+
+  it('loga o carregamento da tela (regra "todo método loga")', async () => {
+    render(<App />)
+    await screen.findByText('43.2.0')
+
+    expect(sendLog).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'info', category: 'ui', msg: 'Tela inicial carregada' })
+    )
+  })
+
+  it('loga como error a falha da ponte, além de mostrá-la', async () => {
+    mockarPonte(() => Promise.reject(new Error('falhou')))
+    render(<App />)
+    await screen.findByRole('alert')
+
+    expect(sendLog).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'error', category: 'ui' })
     )
   })
 })

--- a/src/renderer/src/app/App.tsx
+++ b/src/renderer/src/app/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { AppInfo } from '@shared/contracts/ipc'
+import { log } from '../lib/log'
 
 /**
  * Tela placeholder do bootstrap (Fatia 01). Sem backend real: só prova que o
@@ -12,8 +13,14 @@ export function App(): React.JSX.Element {
   useEffect(() => {
     window.jarvis
       .getAppInfo()
-      .then(setAppInfo)
-      .catch(() => setErro('Não foi possível carregar as informações do app.'))
+      .then((info) => {
+        setAppInfo(info)
+        log.ui.info('Tela inicial carregada', { ambiente: info.environment })
+      })
+      .catch((error: unknown) => {
+        setErro('Não foi possível carregar as informações do app.')
+        log.ui.error('Falha ao carregar informações do app pela ponte', { error })
+      })
   }, [])
 
   return (

--- a/src/renderer/src/lib/log.test.tsx
+++ b/src/renderer/src/lib/log.test.tsx
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { REDACTED_PLACEHOLDER } from '@shared/contracts/logging'
+import { log } from './log'
+
+const sendLog = vi.fn()
+
+function mockarPonte(): void {
+  Object.defineProperty(window, 'jarvis', {
+    value: { getAppInfo: vi.fn(), sendLog },
+    configurable: true,
+    writable: true
+  })
+}
+
+function removerPonte(): void {
+  Object.defineProperty(window, 'jarvis', { value: undefined, configurable: true, writable: true })
+}
+
+beforeEach(() => {
+  sendLog.mockClear()
+  mockarPonte()
+})
+
+describe('logger do renderer', () => {
+  it('encaminha o registro pela ponte, sem escrever em disco', () => {
+    // O renderer não tem acesso ao disco (fronteira de segurança da Fatia 01): tudo o que
+    // ele pode fazer é entregar o registro ao main.
+    log.ui.info('Tela carregada', { rota: '/' })
+
+    expect(sendLog).toHaveBeenCalledWith({
+      level: 'info',
+      category: 'ui',
+      msg: 'Tela carregada',
+      ctx: { rota: '/' }
+    })
+  })
+
+  it.each(['error', 'warn', 'info'] as const)('expõe o nível %s', (nivel) => {
+    log.ui[nivel]('mensagem')
+
+    expect(sendLog).toHaveBeenCalledWith(expect.objectContaining({ level: nivel }))
+  })
+
+  it('redige o segredo antes de atravessar o IPC', () => {
+    // O main redige de novo antes de gravar; redigir aqui evita que o valor sequer trafegue.
+    log.auth.error('Falha ao renovar sessão', { refreshToken: 'rt-secreto' })
+
+    const [registro] = sendLog.mock.calls[0] as [{ ctx: Record<string, unknown> }]
+    expect(registro.ctx['refreshToken']).toBe(REDACTED_PLACEHOLDER)
+    expect(JSON.stringify(sendLog.mock.calls)).not.toContain('rt-secreto')
+  })
+
+  it('não quebra a UI quando a ponte não existe', () => {
+    // Em teste de componente (jsdom) e antes de o preload carregar não há ponte. Um logger
+    // que derruba a tela por não conseguir logar seria pior que o silêncio.
+    removerPonte()
+
+    expect(() => log.ui.info('sem ponte')).not.toThrow()
+    expect(sendLog).not.toHaveBeenCalled()
+  })
+
+  it('oferece todas as categorias do contrato, inclusive as ainda sem fluxo', () => {
+    // `ai`, `agent` e `integracao` nascem em MVPs posteriores. Existirem já com a mesma
+    // assinatura é o que faz o log de in/out nascer padronizado quando elas chegarem.
+    for (const categoria of ['integracao', 'ai', 'agent', 'db', 'auth', 'ipc', 'ui', 'sistema']) {
+      expect(log[categoria as keyof typeof log]).toMatchObject({
+        error: expect.any(Function),
+        warn: expect.any(Function),
+        info: expect.any(Function)
+      })
+    }
+  })
+})

--- a/src/renderer/src/lib/log.ts
+++ b/src/renderer/src/lib/log.ts
@@ -1,0 +1,37 @@
+/**
+ * Logger do renderer — captura e encaminha, nunca escreve.
+ *
+ * O renderer não tem acesso ao disco (fronteira de segurança da Fatia 01), então tudo aqui
+ * atravessa a ponte tipada `window.jarvis.sendLog` e é gravado pelo winston do main.
+ * A API é a mesma do main (`log.ui.info(...)`), para o call site não mudar de forma
+ * conforme o processo.
+ */
+
+import {
+  LOG_CATEGORIES,
+  type CategoryLogger,
+  type LogCategory,
+  type LogContext,
+  type LogLevel
+} from '@shared/contracts/logging'
+import { redactContext } from '@shared/contracts/logging-redaction'
+
+function categoryLogger(category: LogCategory): CategoryLogger {
+  const emit =
+    (level: LogLevel) =>
+    (msg: string, ctx?: LogContext): void => {
+      // Sem a ponte não há para onde mandar — em teste de componente (jsdom) ela não existe,
+      // e um logger que quebra a UI por não conseguir logar seria pior que o silêncio.
+      if (typeof window === 'undefined' || !window.jarvis) return
+
+      // Redige já no renderer: o main redige de novo antes de gravar (defesa em profundidade),
+      // mas assim o segredo nem chega a atravessar o IPC.
+      window.jarvis.sendLog({ level, category, msg, ...(ctx ? { ctx: redactContext(ctx) } : {}) })
+    }
+
+  return { error: emit('error'), warn: emit('warn'), info: emit('info') }
+}
+
+export const log = Object.fromEntries(
+  LOG_CATEGORIES.map((category) => [category, categoryLogger(category)])
+) as Readonly<Record<LogCategory, CategoryLogger>>

--- a/src/shared/contracts/ipc.ts
+++ b/src/shared/contracts/ipc.ts
@@ -7,13 +7,32 @@
  * canal nesta lista e um handler correspondente no main.
  */
 
+import type { LogInput } from './logging'
+
 /** Canais de request/response (renderer → main → renderer). */
 export const IPC_CHANNELS = {
   /** Metadados do app (nome, versão, ambiente). Sem segredo, sem caminho de disco. */
   appInfo: 'app:info'
 } as const
 
+/**
+ * Canais só de ida (renderer → main), sem resposta.
+ *
+ * Separados dos de request/response porque o main os registra com `ipcMain.on`, não
+ * `ipcMain.handle` — e porque o teste que prova "um handler por canal do contrato" precisa
+ * distinguir os dois grupos para não acusar falso positivo.
+ */
+export const IPC_SEND_CHANNELS = {
+  /**
+   * Registro de log vindo do renderer. O renderer nunca escreve em disco (ADR-005): ele
+   * captura e encaminha; quem grava é o winston do main, escritor único.
+   */
+  log: 'log:record'
+} as const
+
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS]
+
+export type IpcSendChannel = (typeof IPC_SEND_CHANNELS)[keyof typeof IPC_SEND_CHANNELS]
 
 /** Informação pública do app exposta ao renderer. */
 export interface AppInfo {
@@ -30,6 +49,8 @@ export interface AppInfo {
  */
 export interface JarvisBridge {
   getAppInfo(): Promise<AppInfo>
+  /** Encaminha um registro de log ao main, que grava. Não devolve nada de propósito. */
+  sendLog(record: LogInput): void
 }
 
 /** Nome da propriedade exposta via contextBridge no renderer. */

--- a/src/shared/contracts/logging-input.spec.ts
+++ b/src/shared/contracts/logging-input.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { parseLogInput } from './logging-input'
+
+describe('parseLogInput', () => {
+  const valido = { level: 'info', category: 'ui', msg: 'Tela carregada' }
+
+  it('aceita o registro mínimo do contrato', () => {
+    expect(parseLogInput(valido)).toEqual(valido)
+  })
+
+  it('aceita os campos opcionais do contrato', () => {
+    const entrada = {
+      ...valido,
+      ctx: { ms: 12 },
+      direction: 'out',
+      workspace: 'noa',
+      correlationId: 'abc-123'
+    }
+
+    expect(parseLogInput(entrada)).toEqual(entrada)
+  })
+
+  it.each([
+    ['nível fora do contrato', { ...valido, level: 'silly' }],
+    ['categoria inventada', { ...valido, category: 'financeiro' }],
+    ['msg vazia', { ...valido, msg: '' }],
+    ['msg não-string', { ...valido, msg: 42 }],
+    ['ctx não-objeto', { ...valido, ctx: 'texto' }],
+    ['direction inválida', { ...valido, direction: 'lateral' }],
+    ['workspace fora do enum', { ...valido, workspace: 'desenvolvimento' }],
+    ['correlationId não-string', { ...valido, correlationId: 7 }]
+  ])('descarta registro com %s', (_caso, entrada) => {
+    expect(parseLogInput(entrada)).toBeUndefined()
+  })
+
+  it.each([
+    ['null', null],
+    ['string', 'log'],
+    ['array', []],
+    ['undefined', undefined]
+  ])('descarta payload que não é objeto (%s)', (_caso, entrada) => {
+    expect(parseLogInput(entrada)).toBeUndefined()
+  })
+
+  it('trunca mensagem longa em vez de descartar o registro', () => {
+    // `msg` é frase curta por contrato; o detalhe vai em `ctx`. Truncar preserva o sinal
+    // sem deixar um registro gigante poluir o arquivo.
+    const saida = parseLogInput({ ...valido, msg: 'a'.repeat(5000) })
+
+    expect(saida?.msg).toHaveLength(2000)
+  })
+
+  it('ignora campos fora do contrato em vez de repassá-los', () => {
+    const saida = parseLogInput({ ...valido, caminhoDoDisco: 'C:/segredo' })
+
+    expect(saida).toEqual(valido)
+  })
+})

--- a/src/shared/contracts/logging-input.ts
+++ b/src/shared/contracts/logging-input.ts
@@ -1,0 +1,61 @@
+/**
+ * Validação do registro que chega do renderer.
+ *
+ * O renderer é fronteira de confiança: o que atravessa o IPC é entrada externa, mesmo sendo
+ * nosso próprio código do outro lado. Um `category` fora do contrato viraria arquivo com
+ * categoria inventada; um `msg` gigante viraria log ilegível. Valida-se aqui, e o que não
+ * casa com o contrato é descartado — não "corrigido em silêncio".
+ */
+
+import {
+  LOG_CATEGORIES,
+  LOG_LEVELS,
+  type LogCategory,
+  type LogInput,
+  type LogLevel
+} from './logging'
+
+const levels = new Set<string>(LOG_LEVELS)
+const categories = new Set<string>(LOG_CATEGORIES)
+const workspaces = new Set(['noa', 'jarvis', 'sistema'])
+const directions = new Set(['in', 'out'])
+
+/** Teto de tamanho da mensagem. `msg` é frase curta por contrato; o detalhe vai em `ctx`. */
+const MAX_MSG_LENGTH = 2000
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Devolve o registro normalizado, ou `undefined` se não casar com o contrato.
+ * `undefined` é descarte deliberado: gravar um registro malformado polui a evidência.
+ */
+export function parseLogInput(value: unknown): LogInput | undefined {
+  if (!isPlainObject(value)) return undefined
+
+  const { level, category, msg, ctx, direction, workspace, correlationId } = value
+
+  if (typeof level !== 'string' || !levels.has(level)) return undefined
+  if (typeof category !== 'string' || !categories.has(category)) return undefined
+  if (typeof msg !== 'string' || msg.length === 0) return undefined
+
+  if (ctx !== undefined && !isPlainObject(ctx)) return undefined
+  if (direction !== undefined && (typeof direction !== 'string' || !directions.has(direction))) {
+    return undefined
+  }
+  if (workspace !== undefined && (typeof workspace !== 'string' || !workspaces.has(workspace))) {
+    return undefined
+  }
+  if (correlationId !== undefined && typeof correlationId !== 'string') return undefined
+
+  return {
+    level: level as LogLevel,
+    category: category as LogCategory,
+    msg: msg.slice(0, MAX_MSG_LENGTH),
+    ...(ctx ? { ctx } : {}),
+    ...(direction ? { direction: direction as 'in' | 'out' } : {}),
+    ...(workspace ? { workspace: workspace as 'noa' | 'jarvis' | 'sistema' } : {}),
+    ...(correlationId ? { correlationId } : {})
+  }
+}

--- a/src/shared/contracts/logging-redaction.spec.ts
+++ b/src/shared/contracts/logging-redaction.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { REDACTED_PLACEHOLDER } from './logging'
+import { redact, redactContext } from './logging-redaction'
+
+describe('redact', () => {
+  it('remove o valor de chave sensível, preservando as vizinhas', () => {
+    const saida = redact({ userId: 'u-1', token: 'ghp_segredo', ms: 842 }) as Record<
+      string,
+      unknown
+    >
+
+    expect(saida['token']).toBe(REDACTED_PLACEHOLDER)
+    expect(saida['userId']).toBe('u-1')
+    expect(saida['ms']).toBe(842)
+  })
+
+  it('reconhece a chave sensível independentemente da caixa', () => {
+    const saida = redact({ Authorization: 'Bearer x', apiKey: 'k', REFRESHTOKEN: 'r' }) as Record<
+      string,
+      unknown
+    >
+
+    expect(Object.values(saida)).toEqual([
+      REDACTED_PLACEHOLDER,
+      REDACTED_PLACEHOLDER,
+      REDACTED_PLACEHOLDER
+    ])
+  })
+
+  it('alcança chave sensível aninhada em objeto e em array', () => {
+    const saida = redact({
+      sessao: { perfil: { nome: 'Rodrigo', accessToken: 'segredo' } },
+      tentativas: [{ password: '123' }]
+    }) as Record<string, Record<string, Record<string, unknown>>>
+
+    expect(saida['sessao']?.['perfil']?.['accessToken']).toBe(REDACTED_PLACEHOLDER)
+    expect(saida['sessao']?.['perfil']?.['nome']).toBe('Rodrigo')
+    expect((saida['tentativas'] as unknown as Record<string, unknown>[])[0]?.['password']).toBe(
+      REDACTED_PLACEHOLDER
+    )
+  })
+
+  it('redige o objeto inteiro quando ele se declara sensível', () => {
+    // Redigir só o rótulo `sensitivity` deixaria o valor rotulado passar — o oposto da regra.
+    const saida = redact({
+      cartao: { sensitivity: 'financial', numero: '4111111111111111' }
+    }) as Record<string, unknown>
+
+    expect(saida['cartao']).toBe(REDACTED_PLACEHOLDER)
+    expect(JSON.stringify(saida)).not.toContain('4111111111111111')
+  })
+
+  it.each(['credential', 'secret', 'personal', 'financial', 'health'])(
+    'redige payload marcado como %s',
+    (sensitivity) => {
+      const saida = redact({ dado: { sensitivity, valor: 'nao-pode-vazar' } }) as Record<
+        string,
+        unknown
+      >
+
+      expect(saida['dado']).toBe(REDACTED_PLACEHOLDER)
+    }
+  )
+
+  it('preserva payload de sensibilidade permitida', () => {
+    const saida = redact({ dado: { sensitivity: 'internal', valor: 'ok' } }) as Record<
+      string,
+      Record<string, unknown>
+    >
+
+    expect(saida['dado']?.['valor']).toBe('ok')
+  })
+
+  it('serializa Error preservando mensagem e stack', () => {
+    // `{...err}` sai vazio: as propriedades de Error não são enumeráveis. Sem este ramo,
+    // a causa da falha se perderia justamente no registro de erro.
+    const erro = new Error('Falha ao gravar')
+    const saida = redact({ error: erro }) as Record<string, Record<string, unknown>>
+
+    expect(saida['error']?.['message']).toBe('Falha ao gravar')
+    expect(saida['error']?.['stack']).toContain('Falha ao gravar')
+  })
+
+  it('não estoura a pilha com estrutura cíclica', () => {
+    const ciclico: Record<string, unknown> = { nome: 'raiz' }
+    ciclico['self'] = ciclico
+
+    const saida = redact(ciclico) as Record<string, unknown>
+
+    expect(saida['nome']).toBe('raiz')
+    expect(saida['self']).toBe('[circular]')
+  })
+
+  it('devolve valores primitivos intactos', () => {
+    expect(redact('texto')).toBe('texto')
+    expect(redact(42)).toBe(42)
+    expect(redact(null)).toBeNull()
+    expect(redact(undefined)).toBeUndefined()
+  })
+
+  it('não altera o objeto de origem', () => {
+    const origem = { token: 'segredo' }
+    redactContext(origem)
+
+    expect(origem.token).toBe('segredo')
+  })
+})

--- a/src/shared/contracts/logging-redaction.ts
+++ b/src/shared/contracts/logging-redaction.ts
@@ -1,0 +1,75 @@
+/**
+ * Redaction — o que nunca chega ao disco.
+ *
+ * Roda no main, como formato do winston, antes de escrever. Fica em `src/shared` porque é
+ * regra pura (CONVENTION §3): nada de Electron, nada de IO, testável direto. O renderer
+ * também importa daqui para não depender de o main ser o único a limpar — defesa em
+ * profundidade barata, já que a mesma função serve os dois.
+ */
+
+import {
+  REDACTED_KEYS,
+  REDACTED_PLACEHOLDER,
+  REDACTED_SENSITIVITIES,
+  type LogContext
+} from './logging'
+
+const redactedKeys = new Set<string>(REDACTED_KEYS.map((key) => key.toLowerCase()))
+const redactedSensitivities = new Set<string>(REDACTED_SENSITIVITIES)
+
+/** Uma chave é sensível pelo nome, independentemente de caixa (`Authorization`, `apiKey`). */
+function isSensitiveKey(key: string): boolean {
+  return redactedKeys.has(key.toLowerCase())
+}
+
+/**
+ * O objeto inteiro é redigido quando ele mesmo se declara sensível — `{ sensitivity:
+ * 'credential', ... }` some por completo, não só o campo `sensitivity`. Redigir apenas o
+ * rótulo deixaria o valor rotulado passar, que é exatamente o que a regra existe para impedir.
+ */
+function declaresSensitivePayload(value: Record<string, unknown>): boolean {
+  const sensitivity = value['sensitivity']
+  return typeof sensitivity === 'string' && redactedSensitivities.has(sensitivity)
+}
+
+/**
+ * Devolve uma cópia sem os valores sensíveis, em qualquer profundidade.
+ *
+ * Estruturas cíclicas viram `'[circular]'` em vez de estourar a pilha: um erro real costuma
+ * carregar objetos com referência de volta (request → socket → request), e um logger que
+ * derruba o processo ao registrar a falha é pior que a falha.
+ */
+export function redact(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+  if (value === null || typeof value !== 'object') return value
+
+  if (seen.has(value)) return '[circular]'
+  seen.add(value)
+
+  // Error não é enumerável: `{...err}` sai vazio e a causa da falha se perde no log.
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack
+    }
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redact(item, seen))
+  }
+
+  const source = value as Record<string, unknown>
+  if (declaresSensitivePayload(source)) return REDACTED_PLACEHOLDER
+
+  const output: Record<string, unknown> = {}
+  for (const [key, item] of Object.entries(source)) {
+    output[key] = isSensitiveKey(key) ? REDACTED_PLACEHOLDER : redact(item, seen)
+  }
+
+  return output
+}
+
+/** Aplica `redact` ao contexto de um registro, preservando o formato de objeto. */
+export function redactContext(ctx: LogContext): LogContext {
+  return redact(ctx) as LogContext
+}

--- a/src/shared/contracts/logging.ts
+++ b/src/shared/contracts/logging.ts
@@ -1,0 +1,133 @@
+/**
+ * Contrato de logging — a forma de todo registro, nos dois processos.
+ *
+ * Governado pelo ADR-005 e detalhado na SPEC-Fundacao-06; o contrato em prosa vive em
+ * `docs/CONVENTION.md` §3. Este arquivo é a versão executável dele: mora em `src/shared`
+ * porque precisa ser testável sem carregar o Electron e porque renderer e main falam a
+ * mesma língua na ponte IPC.
+ *
+ * Fronteira que este contrato preserva (ADR-004): log é observabilidade efêmera, rotaciona
+ * e some. `AuditEvent` é evidência permanente. Um evento pode gerar os dois; um nunca
+ * substitui o outro, e os stores são separados.
+ */
+
+/** Níveis gravados em arquivo. `debug` existe só em dev (console), fora da produção. */
+export const LOG_LEVELS = ['error', 'warn', 'info'] as const
+
+export type LogLevel = (typeof LOG_LEVELS)[number]
+
+/**
+ * Categorias do contrato. As três primeiras ainda não têm fluxo na fundação (`ai`, `agent`
+ * e `integracao` nascem em MVPs posteriores) — estão aqui de propósito: definir a assinatura
+ * agora é o que faz o log de in/out já nascer padronizado quando o subsistema existir.
+ */
+export const LOG_CATEGORIES = [
+  'integracao',
+  'ai',
+  'agent',
+  'db',
+  'auth',
+  'ipc',
+  'ui',
+  'sistema'
+] as const
+
+export type LogCategory = (typeof LOG_CATEGORIES)[number]
+
+/**
+ * Espaço a que o registro pertence. `sistema` cobre o que não tem espaço de usuário —
+ * `Desenvolvimento` não é workspace de usuário (CONVENTION §2), então não entra aqui.
+ */
+export type LogWorkspace = 'noa' | 'jarvis' | 'sistema'
+
+/** Sentido do fluxo, para casar entrada e saída de uma mesma operação via `correlationId`. */
+export type LogDirection = 'in' | 'out'
+
+/** Processo que originou o registro. O renderer nunca escreve em disco — só o main. */
+export type LogSource = 'main' | 'renderer'
+
+/** Contexto estruturado. O detalhe técnico vive aqui; `msg` fica curta e sem segredo. */
+export type LogContext = Record<string, unknown>
+
+/**
+ * O registro estruturado, um objeto por linha no arquivo.
+ *
+ * `msg` é uma frase curta em **pt-BR**, sem stack trace e sem segredo — o stack vai em
+ * `ctx.stack`. Os campos que o chamador não fornece (`ts`, `pid`, `source`, `workspace`)
+ * são preenchidos pelo logger, por isso `LogInput` abaixo é o que se passa na chamada.
+ */
+export interface LogRecord {
+  /** ISO-8601. */
+  readonly ts: string
+  readonly level: LogLevel
+  readonly category: LogCategory
+  readonly direction?: LogDirection
+  readonly workspace: LogWorkspace
+  /** Frase curta em pt-BR. Sem stack, sem segredo. */
+  readonly msg: string
+  readonly ctx: LogContext
+  /** Casa `in` com `out` de uma mesma operação. */
+  readonly correlationId?: string
+  readonly pid: number
+  readonly source: LogSource
+}
+
+/** O que o chamador informa; o logger completa o resto do `LogRecord`. */
+export interface LogInput {
+  readonly level: LogLevel
+  readonly category: LogCategory
+  readonly msg: string
+  readonly ctx?: LogContext
+  readonly direction?: LogDirection
+  readonly workspace?: LogWorkspace
+  readonly correlationId?: string
+}
+
+/**
+ * Assinatura do logger, igual nos dois processos. Um child logger por categoria mantém a
+ * chamada curta no call site (`log.ipc.info('...')`) sem repetir a categoria a cada linha.
+ */
+export interface CategoryLogger {
+  error(msg: string, ctx?: LogContext): void
+  warn(msg: string, ctx?: LogContext): void
+  info(msg: string, ctx?: LogContext): void
+}
+
+/**
+ * Chaves cujo **valor** nunca é gravado, em qualquer profundidade do `ctx`.
+ *
+ * Comparação é case-insensitive: um payload externo pode chegar como `Authorization` ou
+ * `apiKey`, e uma lista sensível a maiúscula deixaria passar. Ver `redact()` em
+ * `src/shared/contracts/logging-redaction.ts`.
+ */
+export const REDACTED_KEYS = [
+  'token',
+  'password',
+  'secret',
+  'authorization',
+  'accessToken',
+  'refreshToken',
+  'apiKey'
+] as const
+
+/**
+ * Classificações de `sensitivity` (CONVENTION §2) que nunca vão para o log.
+ * `personal | financial | health` são mascaradas: JARVIS não loga esses sem aprovação.
+ */
+export const REDACTED_SENSITIVITIES = [
+  'credential',
+  'secret',
+  'personal',
+  'financial',
+  'health'
+] as const
+
+/** Marcador que substitui o valor removido — deixa visível *que* houve redaction. */
+export const REDACTED_PLACEHOLDER = '[redigido]'
+
+/** Retenção em dias, por nível (SPEC-Fundacao-06; decisão do PI em 2026-07-21). */
+export const LOG_RETENTION_DAYS: Readonly<Record<LogLevel, number>> = {
+  info: 3,
+  warn: 7,
+  error: 10
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,7 +33,10 @@ export default defineConfig({
         test: {
           name: 'banco',
           environment: 'node',
-          include: ['src/main/**/*.int-spec.ts', 'tests/**/*.int-spec.ts']
+          include: ['src/main/**/*.int-spec.ts', 'tests/**/*.int-spec.ts'],
+          // Integração toca disco e singletons de processo (o logger é um): em paralelo,
+          // um arquivo derruba o outro. Serial é o que torna a categoria determinística.
+          fileParallelism: false
         }
       },
       {


### PR DESCRIPTION
refs #8

Implementa a `SPEC-Fundacao-06` (`aprovada-pi` 2026-07-21, emendada em 2026-07-22), governada pelo ADR-005.

## O que entra

**Escritor único.** O `winston` no main é o único que toca o disco. O renderer captura e encaminha — por `window.jarvis.sendLog` (canal tipado, só de ida) e por `electron-log`, que pega `console.*` inclusive de dependências que nunca conheceriam a nossa ponte. Os transports de arquivo do `electron-log` ficam desligados: dois donos do mesmo arquivo quebrariam a rotação.

**Um arquivo por nível, com filtro de nível exato.** `level: 'info'` num transport do winston significa "info **e tudo mais severo**". Sem o filtro, os `error` cairiam também no arquivo de info e seriam podados em **3 dias em vez de 10** — a retenção por nível decidida pelo PI (info 3d / warn 7d / error 10d, zipada) deixaria de valer no disco.

**Redaction nos dois lados.** Regra pura em `src/shared` (sem Electron, sem IO, testável direto), aplicada no renderer — para o segredo não chegar a trafegar no IPC — e de novo no main antes de gravar. Objeto que se declara `sensitivity: credential|secret|personal|financial|health` é redigido **inteiro**: redigir só o campo `sensitivity` deixaria o valor rotulado passar.

**Payload do IPC é validado.** O renderer é fronteira de confiança mesmo sendo nosso código. `parseLogInput` descarta registro fora do contrato (nível inexistente, categoria inventada) e não deixa o renderer forjar `source`. Descartar é deliberado — registro malformado polui a evidência.

**Instrumentação.** `ipc`, `sistema` e `ui`, que é o que existe quando o F06 executa. `auth` (F03), `db` (F04) e workspace-switch (F02) instrumentam nas próprias fatias, conforme a emenda do PI de 2026-07-22. As categorias `ai`/`agent`/`integracao` já existem com a mesma assinatura, para nascerem padronizadas.

## Sobre o gotcha do `.gz`

A spec alerta que a poda poderia não alcançar os `.gz`, porque o `file-stream-rotator` apaga `file.name` — o nome **sem** a extensão. Verificado no código da versão instalada (`winston-daily-rotate-file@5.0.0`): o evento `logRemoved` apaga `params.name + '.gz'`. **Há teste provando isso na versão instalada**, em vez de confiar na leitura — se um upgrade regredir, o teste cai.

## Teste

- **70 testes verdes** (era 18); `lint` e `typecheck` limpos
- Redaction provada **contra o arquivo em disco**, não só contra a função: o token não está lá
- Separação por nível verificada arquivo a arquivo (sem transbordo do mais severo)
- **Verificado no app real:** os três arquivos nascem em `userData/logs` e o registro do renderer chega ao disco com `source: "renderer"`

Sem `closes` — o aceite é do PI.