### PR TITLE
[MVP1][F03] Autenticação Google local-first

### DIFF
--- a/.claude/hooks/office3d.js
+++ b/.claude/hooks/office3d.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * Office3D Hook — cross-platform (Windows/Mac/Linux)
+ * Encaminha eventos do Claude Code para o escritório 3D.
+ *
+ * Instalação: copie para <SEU_PROJETO>/.claude/hooks/office3d.js
+ */
+
+const http = require('http')
+const OFFICE3D_URL = process.env.OFFICE3D_URL || 'http://localhost:3001'
+
+const chunks = []
+process.stdin.on('data', (d) => chunks.push(d))
+process.stdin.on('end', () => {
+  const payload = Buffer.concat(chunks).toString('utf-8')
+
+  try {
+    const url = new URL('/hook', OFFICE3D_URL)
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: Number(url.port) || 3001,
+        path: url.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+        },
+      },
+      () => {} // ignora resposta
+    )
+    req.on('error', () => {}) // silencia erros (backend pode estar off)
+    req.write(payload)
+    req.end()
+  } catch (_) {}
+
+  // Sempre exit 0 — nunca bloqueia o Claude Code
+  process.exit(0)
+})

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,50 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/office3d.js"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/office3d.js"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/office3d.js"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/office3d.js"
+          }
+        ]
+      }
     ]
   },
   "language": "portuguese"

--- a/.env.example
+++ b/.env.example
@@ -26,5 +26,14 @@ SUPABASE_PUBLISHABLE_KEY=
 # Depois de criar o cliente, registre-o no Supabase em Authentication → Providers →
 # Google, e acrescente a URL de callback do Supabase às "URIs de redirecionamento
 # autorizados" do cliente no Google Cloud.
+#
+# IMPORTANTE — **o app não lê estas duas variáveis** (verificado na entrega da F03).
+# No desenho do ADR-002 quem conversa com o Google é o Supabase, não o desktop: o ID e o
+# secret vivem no painel do Supabase, e o app só fala com o Supabase usando a chave
+# publicável acima. Elas ficam documentadas aqui porque são parte da configuração que o
+# PI precisa fazer — não porque o processo as carregue.
+#
+# Um client secret embarcado num app desktop distribuído não seria segredo: qualquer
+# usuário o extrai do binário. É justamente por isso que ele fica do lado do servidor.
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,28 +171,6 @@ jobs:
             > "$HOME/.local/share/keyrings/Default_keyring.keyring"
           printf Default_keyring > "$HOME/.local/share/keyrings/default"
 
-      # DIAGNÓSTICO TEMPORÁRIO — remover quando o E2E estiver verde.
-      # O chmod acima derrubou o FATAL do SUID sandbox, mas o `firstWindow()` segue
-      # estourando: sobra outra barreira no boot. O reporter do Playwright engole o
-      # stderr do processo, então subimos o app fora dele para ler o erro cru.
-      - name: Diagnóstico — subir o Electron e capturar stderr
-        continue-on-error: true
-        run: |
-          npm run build
-          dbus-run-session -- bash -c '
-            rm -rf "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/keyring"
-            eval "$(gnome-keyring-daemon --components=secrets --daemonize)" || echo "daemon FALHOU: $?"
-            echo -n teste | secret-tool store --label=sonda sonda ci \
-              && secret-tool lookup sonda ci \
-              && echo "secret-tool OK — caminho libsecret funciona" \
-              || echo "secret-tool FALHOU — o Chromium também vai falhar"
-            dbus-send --session --print-reply --dest=org.freedesktop.DBus \
-              /org/freedesktop/DBus org.freedesktop.DBus.ListNames \
-              | grep -i secret || echo "SEM org.freedesktop.secrets no bus"
-            timeout 40 xvfb-run --auto-servernum \
-              node_modules/.bin/electron . --user-data-dir=/tmp/diag 2>&1 | head -60
-          ' || true
-
       # `xvfb-run`: o orquestrador roda o E2E, e o Electron abre janela — sem display
       # virtual o launch falha no Linux do CI (docs/TESTING.md §3.1).
       - name: Rodar testes + guarda anti-drift

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,8 @@ jobs:
         run: |
           npm run build
           dbus-run-session -- bash -c '
-            eval "$(gnome-keyring-daemon --components=secrets --start)" || echo "start FALHOU: $?"
+            rm -rf "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/keyring"
+            eval "$(gnome-keyring-daemon --components=secrets --daemonize)" || echo "daemon FALHOU: $?"
             echo -n teste | secret-tool store --label=sonda sonda ci \
               && secret-tool lookup sonda ci \
               && echo "secret-tool OK — caminho libsecret funciona" \
@@ -199,7 +200,10 @@ jobs:
           REPORT_BASE_REF: origin/${{ github.base_ref }}
         run: |
           dbus-run-session -- bash -c '
-            eval "$(gnome-keyring-daemon --components=secrets --start)"
+            rm -rf "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/keyring"
+            eval "$(gnome-keyring-daemon --components=secrets --daemonize)"
+            echo -n teste | secret-tool store --label=sonda sonda ci \
+              && echo "secret-tool OK" || echo "secret-tool FALHOU — Electron vai falhar"
             exec xvfb-run --auto-servernum npm run test:report:check
           '
 
@@ -211,7 +215,8 @@ jobs:
         if: env.REQUIRE_ENTRY == '1'
         run: |
           dbus-run-session -- bash -c '
-            eval "$(gnome-keyring-daemon --components=secrets --start)"
+            rm -rf "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/keyring"
+            eval "$(gnome-keyring-daemon --components=secrets --daemonize)"
             exec xvfb-run --auto-servernum npm run test:report:check -- --require-entry
           '
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,12 +151,14 @@ jobs:
       # provar a garantia. Os daemons sobrevivem ao fim do step; os steps seguintes só
       # precisam do endereço do bus e do desktop declarado — sem XDG_CURRENT_DESKTOP o
       # Chromium nem tenta o libsecret e volta ao basic_text.
+      # O daemon precisa viver NO MESMO comando que roda os testes: sessão D-Bus e
+      # keyring iniciados num step anterior não são confiáveis aqui (o primeiro run com
+      # eval $(dbus-launch) + GITHUB_ENV chegou com o bus certo e o safeStorage seguiu
+      # indisponível). `dbus-run-session` cria o bus, o unlock com senha vazia cria e
+      # destrava o keyring "login", e o processo de teste herda tudo por descendência.
       - name: Keyring real para o safeStorage (ADR-004)
         run: |
-          sudo apt-get install -y gnome-keyring dbus-x11
-          eval "$(dbus-launch --sh-syntax)"
-          echo -n '' | gnome-keyring-daemon --unlock --components=secrets
-          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
+          sudo apt-get install -y gnome-keyring
           echo "XDG_CURRENT_DESKTOP=GNOME" >> "$GITHUB_ENV"
 
       # DIAGNÓSTICO TEMPORÁRIO — remover quando o E2E estiver verde.
@@ -166,17 +168,26 @@ jobs:
       - name: Diagnóstico — subir o Electron e capturar stderr
         continue-on-error: true
         run: |
-          ls -l node_modules/electron/dist/chrome-sandbox
           npm run build
-          timeout 40 xvfb-run --auto-servernum \
-            node_modules/.bin/electron . --user-data-dir=/tmp/diag 2>&1 | head -80 || true
+          dbus-run-session -- bash -c '
+            echo -n "" | gnome-keyring-daemon --unlock --components=secrets || echo "keyring FALHOU: $?"
+            dbus-send --session --print-reply --dest=org.freedesktop.DBus \
+              /org/freedesktop/DBus org.freedesktop.DBus.ListNames \
+              | grep -i secret || echo "SEM org.freedesktop.secrets no bus"
+            timeout 40 xvfb-run --auto-servernum \
+              node_modules/.bin/electron . --user-data-dir=/tmp/diag 2>&1 | head -60
+          ' || true
 
       # `xvfb-run`: o orquestrador roda o E2E, e o Electron abre janela — sem display
       # virtual o launch falha no Linux do CI (docs/TESTING.md §3.1).
       - name: Rodar testes + guarda anti-drift
         env:
           REPORT_BASE_REF: origin/${{ github.base_ref }}
-        run: xvfb-run --auto-servernum npm run test:report:check
+        run: |
+          dbus-run-session -- bash -c '
+            echo -n "" | gnome-keyring-daemon --unlock --components=secrets
+            exec xvfb-run --auto-servernum npm run test:report:check
+          '
 
       # Terceira guarda: números certos + histórico íntegro ainda deixavam
       # passar uma entrega SEM linha no histórico — no repo de origem duas
@@ -184,7 +195,11 @@ jobs:
       # depois do --check para que a falha de números apareça antes.
       - name: Guarda — a entrega está carimbada no histórico?
         if: env.REQUIRE_ENTRY == '1'
-        run: xvfb-run --auto-servernum npm run test:report:check -- --require-entry
+        run: |
+          dbus-run-session -- bash -c '
+            echo -n "" | gnome-keyring-daemon --unlock --components=secrets
+            exec xvfb-run --auto-servernum npm run test:report:check -- --require-entry
+          '
 
       - name: Publicar tabela no job summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,16 @@ jobs:
       - name: Baixar o binário do Electron
         run: node node_modules/electron/install.js
 
-      - name: Lint e typecheck
+      # `npm run build` = typecheck + `electron-vite build`. O build é o que produz
+      # `out/main/index.js`, o `main` do package.json — e `out/` é gitignored, então
+      # no runner ele só existe se for construído aqui. Sem este passo o Electron sobe
+      # apontando para um arquivo inexistente, o processo morre e o `firstWindow()` do
+      # E2E espera a janela até estourar 30s. O sintoma engana igual ao do binário
+      # acima: timeout de janela, nenhum erro de módulo no log.
+      - name: Lint e build (typecheck + bundle do Electron)
         run: |
           npm run lint
-          npm run typecheck
+          npm run build
 
       # O append-only é verificado contra a BASE do PR, não contra HEAD: aqui
       # HEAD é o merge commit, cujo TESTS.md é a versão do próprio PR — a guarda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,13 @@ jobs:
       # destrava o keyring "login", e o processo de teste herda tudo por descendência.
       - name: Keyring real para o safeStorage (ADR-004)
         run: |
-          sudo apt-get install -y gnome-keyring
+          sudo apt-get install -y gnome-keyring libsecret-tools
           echo "XDG_CURRENT_DESKTOP=GNOME" >> "$GITHUB_ENV"
+          # O Chromium grava na collection *default*; sem o alias apontando para o
+          # keyring `login`, o gnome-keyring tenta CRIAR uma collection — o que abre o
+          # SystemPrompter (GUI) e morre no runner. Semear o alias no disco evita o prompt.
+          mkdir -p "$HOME/.local/share/keyrings"
+          printf login > "$HOME/.local/share/keyrings/default"
 
       # DIAGNÓSTICO TEMPORÁRIO — remover quando o E2E estiver verde.
       # O chmod acima derrubou o FATAL do SUID sandbox, mas o `firstWindow()` segue
@@ -172,6 +177,10 @@ jobs:
           dbus-run-session -- bash -c '
             eval "$(echo -n "" | gnome-keyring-daemon --login)" || echo "login FALHOU: $?"
             eval "$(gnome-keyring-daemon --components=secrets --start)" || echo "start FALHOU: $?"
+            echo -n teste | secret-tool store --label=sonda sonda ci \
+              && secret-tool lookup sonda ci \
+              && echo "secret-tool OK — caminho libsecret funciona" \
+              || echo "secret-tool FALHOU — o Chromium também vai falhar"
             dbus-send --session --print-reply --dest=org.freedesktop.DBus \
               /org/freedesktop/DBus org.freedesktop.DBus.ListNames \
               | grep -i secret || echo "SEM org.freedesktop.secrets no bus"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,16 +73,10 @@ jobs:
       - name: Baixar o binário do Electron
         run: node node_modules/electron/install.js
 
-      # `npm run build` = typecheck + `electron-vite build`. O build é o que produz
-      # `out/main/index.js`, o `main` do package.json — e `out/` é gitignored, então
-      # no runner ele só existe se for construído aqui. Sem este passo o Electron sobe
-      # apontando para um arquivo inexistente, o processo morre e o `firstWindow()` do
-      # E2E espera a janela até estourar 30s. O sintoma engana igual ao do binário
-      # acima: timeout de janela, nenhum erro de módulo no log.
-      - name: Lint e build (typecheck + bundle do Electron)
+      - name: Lint e typecheck
         run: |
           npm run lint
-          npm run build
+          npm run typecheck
 
       # O append-only é verificado contra a BASE do PR, não contra HEAD: aqui
       # HEAD é o merge commit, cujo TESTS.md é a versão do próprio PR — a guarda
@@ -126,17 +120,24 @@ jobs:
             echo "PR não altera teste — carimbo dispensado."
           fi
 
-      # DIAGNÓSTICO TEMPORÁRIO: sobe o app fora do Playwright e mostra o stderr cru.
-      # O `firstWindow()` só reporta "timeout esperando window" — o motivo real de o
-      # processo não abrir janela fica no stderr, que o reporter do Playwright engole.
-      # Remover assim que a causa estiver identificada.
-      - name: Diagnóstico — subir o Electron e capturar stderr
-        continue-on-error: true
+      # O `chrome-sandbox` que vem no pacote npm não tem as permissões que o Chromium
+      # exige no Linux (dono root, modo 4755) — o npm não preserva setuid. Sem isto o
+      # processo aborta no boot, ANTES de criar janela:
+      #
+      #   FATAL:setuid_sandbox_host.cc:166] The SUID sandbox helper binary was found,
+      #   but is not configured correctly. (…) exited with signal SIGTRAP
+      #
+      # O sintoma engana: o E2E só mostra "timeout esperando o evento window", porque
+      # o stderr do processo não chega ao reporter do Playwright.
+      #
+      # A alternativa seria subir com `--no-sandbox`, e ela está DESCARTADA: o sandbox
+      # do renderer é critério de aceite da SPEC-Fundacao-03 (a mesma razão que mantém
+      # o preload em .cjs). Desligá-lo no CI faria a suíte passar exatamente onde ela
+      # deveria provar a fronteira — teste verde sobre a garantia ausente.
+      - name: Ajustar permissões do chrome-sandbox (setuid)
         run: |
-          set -x
-          ls -la out/main/index.js out/preload/index.cjs out/renderer/index.html
-          timeout 30 xvfb-run --auto-servernum \
-            node_modules/.bin/electron . --user-data-dir=/tmp/diag 2>&1 | head -60 || true
+          sudo chown root:root node_modules/electron/dist/chrome-sandbox
+          sudo chmod 4755 node_modules/electron/dist/chrome-sandbox
 
       # `xvfb-run`: o orquestrador roda o E2E, e o Electron abre janela — sem display
       # virtual o launch falha no Linux do CI (docs/TESTING.md §3.1).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,8 @@ jobs:
         run: |
           npm run build
           dbus-run-session -- bash -c '
-            echo -n "" | gnome-keyring-daemon --unlock --components=secrets || echo "keyring FALHOU: $?"
+            eval "$(echo -n "" | gnome-keyring-daemon --login)" || echo "login FALHOU: $?"
+            eval "$(gnome-keyring-daemon --components=secrets --start)" || echo "start FALHOU: $?"
             dbus-send --session --print-reply --dest=org.freedesktop.DBus \
               /org/freedesktop/DBus org.freedesktop.DBus.ListNames \
               | grep -i secret || echo "SEM org.freedesktop.secrets no bus"
@@ -185,7 +186,8 @@ jobs:
           REPORT_BASE_REF: origin/${{ github.base_ref }}
         run: |
           dbus-run-session -- bash -c '
-            echo -n "" | gnome-keyring-daemon --unlock --components=secrets
+            eval "$(echo -n "" | gnome-keyring-daemon --login)"
+            eval "$(gnome-keyring-daemon --components=secrets --start)"
             exec xvfb-run --auto-servernum npm run test:report:check
           '
 
@@ -197,7 +199,8 @@ jobs:
         if: env.REQUIRE_ENTRY == '1'
         run: |
           dbus-run-session -- bash -c '
-            echo -n "" | gnome-keyring-daemon --unlock --components=secrets
+            eval "$(echo -n "" | gnome-keyring-daemon --login)"
+            eval "$(gnome-keyring-daemon --components=secrets --start)"
             exec xvfb-run --auto-servernum npm run test:report:check -- --require-entry
           '
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Instalar dependências
         run: npm ci
 
+      # O E2E sobe o Electron de verdade (SPEC-Fundacao-03, critério 9), e no Linux
+      # do CI isso exige as libs de sistema que o Playwright instala. `--with-deps`
+      # cobre exatamente esse caso.
+      - name: Instalar dependências de sistema do Playwright
+        run: npx playwright install-deps
+
       - name: Lint e typecheck
         run: |
           npm run lint
@@ -98,7 +104,7 @@ jobs:
           # arquivo removido: apagar um spec não cria entrega a carimbar.
           changed=$(git diff --name-only --diff-filter=d \
             "origin/${{ github.base_ref }}..HEAD" \
-            -- '*.spec.ts' '*.int-spec.ts' '*.test.ts' '*.test.tsx' '*.selfcheck.mjs')
+            -- '*.spec.ts' '*.int-spec.ts' '*.test.ts' '*.test.tsx' '*.e2e.ts' '*.selfcheck.mjs')
           if [ -n "$changed" ]; then
             echo "REQUIRE_ENTRY=1" >> "$GITHUB_ENV"
             echo "PR altera testes — o carimbo no histórico será exigido:"
@@ -107,10 +113,12 @@ jobs:
             echo "PR não altera teste — carimbo dispensado."
           fi
 
+      # `xvfb-run`: o orquestrador roda o E2E, e o Electron abre janela — sem display
+      # virtual o launch falha no Linux do CI (docs/TESTING.md §3.1).
       - name: Rodar testes + guarda anti-drift
         env:
           REPORT_BASE_REF: origin/${{ github.base_ref }}
-        run: npm run test:report:check
+        run: xvfb-run --auto-servernum npm run test:report:check
 
       # Terceira guarda: números certos + histórico íntegro ainda deixavam
       # passar uma entrega SEM linha no histórico — no repo de origem duas
@@ -118,7 +126,7 @@ jobs:
       # depois do --check para que a falha de números apareça antes.
       - name: Guarda — a entrega está carimbada no histórico?
         if: env.REQUIRE_ENTRY == '1'
-        run: npm run test:report:check -- --require-entry
+        run: xvfb-run --auto-servernum npm run test:report:check -- --require-entry
 
       - name: Publicar tabela no job summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,18 @@ jobs:
             echo "PR não altera teste — carimbo dispensado."
           fi
 
+      # DIAGNÓSTICO TEMPORÁRIO: sobe o app fora do Playwright e mostra o stderr cru.
+      # O `firstWindow()` só reporta "timeout esperando window" — o motivo real de o
+      # processo não abrir janela fica no stderr, que o reporter do Playwright engole.
+      # Remover assim que a causa estiver identificada.
+      - name: Diagnóstico — subir o Electron e capturar stderr
+        continue-on-error: true
+        run: |
+          set -x
+          ls -la out/main/index.js out/preload/index.cjs out/renderer/index.html
+          timeout 30 xvfb-run --auto-servernum \
+            node_modules/.bin/electron . --user-data-dir=/tmp/diag 2>&1 | head -60 || true
+
       # `xvfb-run`: o orquestrador roda o E2E, e o Electron abre janela — sem display
       # virtual o launch falha no Linux do CI (docs/TESTING.md §3.1).
       - name: Rodar testes + guarda anti-drift

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,16 @@ jobs:
         run: |
           sudo apt-get install -y gnome-keyring libsecret-tools
           echo "XDG_CURRENT_DESKTOP=GNOME" >> "$GITHUB_ENV"
-          # O Chromium grava na collection *default*; sem o alias apontando para o
-          # keyring `login`, o gnome-keyring tenta CRIAR uma collection — o que abre o
-          # SystemPrompter (GUI) e morre no runner. Semear o alias no disco evita o prompt.
+          # O Chromium grava na collection *default*. Criar keyring/collection em
+          # runtime exige o SystemPrompter (GUI), que morre no runner — e o --login com
+          # senha vazia não materializa o arquivo. Então o keyring inteiro é semeado no
+          # disco: sem hash de senha o formato é texto claro e nasce DESTRAVADO — para
+          # segredo descartável de CI, é exatamente o que se quer.
           mkdir -p "$HOME/.local/share/keyrings"
-          printf login > "$HOME/.local/share/keyrings/default"
+          printf '%s\n' '[keyring]' 'display-name=Default keyring' 'ctime=0' 'mtime=0' \
+            'lock-on-idle=false' 'lock-after=false' \
+            > "$HOME/.local/share/keyrings/Default_keyring.keyring"
+          printf Default_keyring > "$HOME/.local/share/keyrings/default"
 
       # DIAGNÓSTICO TEMPORÁRIO — remover quando o E2E estiver verde.
       # O chmod acima derrubou o FATAL do SUID sandbox, mas o `firstWindow()` segue
@@ -175,7 +180,6 @@ jobs:
         run: |
           npm run build
           dbus-run-session -- bash -c '
-            eval "$(echo -n "" | gnome-keyring-daemon --login)" || echo "login FALHOU: $?"
             eval "$(gnome-keyring-daemon --components=secrets --start)" || echo "start FALHOU: $?"
             echo -n teste | secret-tool store --label=sonda sonda ci \
               && secret-tool lookup sonda ci \
@@ -195,7 +199,6 @@ jobs:
           REPORT_BASE_REF: origin/${{ github.base_ref }}
         run: |
           dbus-run-session -- bash -c '
-            eval "$(echo -n "" | gnome-keyring-daemon --login)"
             eval "$(gnome-keyring-daemon --components=secrets --start)"
             exec xvfb-run --auto-servernum npm run test:report:check
           '
@@ -208,7 +211,6 @@ jobs:
         if: env.REQUIRE_ENTRY == '1'
         run: |
           dbus-run-session -- bash -c '
-            eval "$(echo -n "" | gnome-keyring-daemon --login)"
             eval "$(gnome-keyring-daemon --components=secrets --start)"
             exec xvfb-run --auto-servernum npm run test:report:check -- --require-entry
           '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,18 @@ jobs:
           sudo chown root:root node_modules/electron/dist/chrome-sandbox
           sudo chmod 4755 node_modules/electron/dist/chrome-sandbox
 
+      # DIAGNÓSTICO TEMPORÁRIO — remover quando o E2E estiver verde.
+      # O chmod acima derrubou o FATAL do SUID sandbox, mas o `firstWindow()` segue
+      # estourando: sobra outra barreira no boot. O reporter do Playwright engole o
+      # stderr do processo, então subimos o app fora dele para ler o erro cru.
+      - name: Diagnóstico — subir o Electron e capturar stderr
+        continue-on-error: true
+        run: |
+          ls -l node_modules/electron/dist/chrome-sandbox
+          npm run build
+          timeout 40 xvfb-run --auto-servernum \
+            node_modules/.bin/electron . --user-data-dir=/tmp/diag 2>&1 | head -80 || true
+
       # `xvfb-run`: o orquestrador roda o E2E, e o Electron abre janela — sem display
       # virtual o launch falha no Linux do CI (docs/TESTING.md §3.1).
       - name: Rodar testes + guarda anti-drift

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,17 @@ jobs:
         run: npm ci
 
       # O E2E sobe o Electron de verdade (SPEC-Fundacao-03, critério 9), e no Linux
-      # do CI isso exige as libs de sistema que o Playwright instala. `--with-deps`
-      # cobre exatamente esse caso.
+      # do CI isso exige as libs de sistema que o Playwright instala.
       - name: Instalar dependências de sistema do Playwright
         run: npx playwright install-deps
+
+      # Baixa o binário do Electron ANTES dos testes. O `postinstall` do projeto é
+      # `electron-rebuild` (compila o better-sqlite3), que **não** baixa o binário — e o
+      # download de ~100 MB acontecia dentro do primeiro teste, estourando os 30s do
+      # `firstWindow()`. O sintoma engana: o processo sobe e a janela nunca abre, sem
+      # erro de biblioteca no log. Fora do teste, o tempo de download não conta no timeout.
+      - name: Baixar o binário do Electron
+        run: node node_modules/electron/install.js
 
       - name: Lint e typecheck
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,26 @@ jobs:
           sudo chown root:root node_modules/electron/dist/chrome-sandbox
           sudo chmod 4755 node_modules/electron/dist/chrome-sandbox
 
+      # O runner não tem D-Bus de sessão nem keyring, então o backend de senha do
+      # Chromium cai em `basic_text` e `safeStorage.isEncryptionAvailable()` responde
+      # false. O boot então falha ALTO por desenho (ADR-004: a chave de auditoria nunca
+      # vai ao disco em claro) e a janela não nasce — o E2E vê só "timeout esperando
+      # window"; o erro real só aparece no stderr do processo principal.
+      #
+      # A saída é dar ao CI um keyring REAL: gnome-keyring destravado sobre um D-Bus de
+      # sessão. Afrouxar o código (gravar em claro sob flag de teste) está DESCARTADO
+      # pela mesma razão do sandbox acima: a suíte passaria exatamente onde deveria
+      # provar a garantia. Os daemons sobrevivem ao fim do step; os steps seguintes só
+      # precisam do endereço do bus e do desktop declarado — sem XDG_CURRENT_DESKTOP o
+      # Chromium nem tenta o libsecret e volta ao basic_text.
+      - name: Keyring real para o safeStorage (ADR-004)
+        run: |
+          sudo apt-get install -y gnome-keyring dbus-x11
+          eval "$(dbus-launch --sh-syntax)"
+          echo -n '' | gnome-keyring-daemon --unlock --components=secrets
+          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
+          echo "XDG_CURRENT_DESKTOP=GNOME" >> "$GITHUB_ENV"
+
       # DIAGNÓSTICO TEMPORÁRIO — remover quando o E2E estiver verde.
       # O chmod acima derrubou o FATAL do SUID sandbox, mas o `firstWindow()` segue
       # estourando: sobra outra barreira no boot. O reporter do Playwright engole o

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ graphify-out
 .env
 .env.*
 !.env.example
+
+# Artefatos do Playwright (E2E) — saída de execução, não fonte.
+test-results
+playwright-report

--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,7 @@ docs
 .gemini
 .antigravity
 graphify-out
+
+# Artefatos do Playwright (E2E).
+test-results
+playwright-report

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -76,19 +76,25 @@ Status: spec `aprovada-pi` (2026-07-21); issue #3 em Backlog. Depende da Fatia 0
 
 ### Fatia 03 — Autenticação Google local-first (`docs/spec/spec-fundacao-03-auth-google.md`)
 
-Status: spec `aprovada-pi` (2026-07-21); issue #4 em Backlog. **BLOQUEADA — aguarda o PI.** Depende da Fatia 01; consome contratos da 04 (já entregues).
+Status: **entregue** — spec `aprovada-pi` (2026-07-21, emendada em 2026-07-22); issue #4; PR [#30](https://github.com/RodReis/rrb-jarvisOS/pull/30). Desbloqueada em 2026-07-22, quando o PI criou o projeto Supabase e o cliente OAuth e preencheu o `.env`. Fecha o MVP-001.
 
-> **O que falta para desbloquear (só o PI pode fazer):** criar o projeto Supabase de desenvolvimento e o cliente OAuth no Google Cloud, e preencher o `.env` local. O `.env.example` na raiz lista as quatro variáveis e onde obter cada uma. Enquanto isso não existe, os critérios 1 (login real), 2 (relançamento offline), 7 (token cifrado) e 9 (E2E do login) são inverificáveis — não há o que testar sem um provedor de identidade. A infra que a fatia consome (`Session`, `UserProfile`, `AuditEvent`, tipos `login`/`logout`/`login-offline-reuse`) **já está entregue** na F04.
+- [x] Projeto Supabase dev na nuvem configurado (ADR-002); env local sem segredo commitado (`.env` no `.gitignore`, verificado)
+- [x] Fluxo OAuth **PKCE** no navegador do sistema + retorno via **loopback local** efêmero (`127.0.0.1`, porta do SO, morre após uma requisição)
+- [x] Sessão offline válida por **30 dias** antes de exigir reautenticação (ADR-001); testado nos dois limites da janela
+- [x] Persistência de sessão no main process **cifrada via `safeStorage`/DPAPI**; o teste lê os bytes do arquivo para provar que o token não está em claro
+- [x] Estados: deslogado / autenticando / ativo / erro / sessão-expirada, com mensagens de enum fechado (sem `error.message` cru na UI)
+- [x] Relançamento offline reusa sessão sem tocar a rede; logout revoga quando online e **sempre** limpa o local
+- [x] AuditEvents de login/logout/login-offline-reuse
+- [x] Instrumenta o logger na categoria `auth` (emenda do PI de 2026-07-22) com **redaction comprovada** — teste varre todos os registros atrás de access/refresh token
+- [x] Testes do fluxo (unit com Supabase dublado) **+ E2E Playwright-Electron** — a categoria E2E do relatório passa a ter contagem real (ADR-003)
+- [x] Entrega: PR [#30](https://github.com/RodReis/rrb-jarvisOS/pull/30) (`refs #4`); docs/ commitados
 
-- [ ] Projeto Supabase dev na nuvem configurado (ADR-002); env local sem segredo commitado
-- [ ] Fluxo OAuth no navegador do sistema + retorno via **loopback local**
-- [ ] Sessão offline válida por **30 dias** antes de exigir reautenticação (ADR-001)
-- [ ] Persistência de sessão no main process **cifrada via `safeStorage`/DPAPI** (token nunca em claro no disco); renderer só vê snapshot de perfil
-- [ ] Estados: deslogado / autenticando / ativo / erro / sessão-expirada
-- [ ] Relançamento offline reusa sessão; logout limpa estado sensível
-- [ ] AuditEvents de login/logout/login-offline-reuse
-- [ ] Testes do fluxo (unit com mock) **+ E2E Playwright-Electron do login feliz** (firmado — alimenta a categoria E2E do relatório, ADR-003)
-- [ ] Entrega: PR `refs #N`; docs/ commitados
+**Decisões e achados desta fatia:**
+
+1. **O `GOOGLE_OAUTH_CLIENT_SECRET` do `.env` não é usado pelo app** — e não deve ser. No desenho do ADR-002 quem fala com o Google é o Supabase; o secret vive no painel dele (Authentication → Providers → Google). Um secret embarcado em app desktop distribuído não é segredo: qualquer usuário o extrai do binário. Decisão do PI (2026-07-22): manter a variável no `.env` sem uso, em vez de removê-la.
+2. **`findMostRecent()` é a única consulta sem escopo de `user_id`** — exceção deliberada, documentada no próprio método. No boot o app precisa descobrir *de quem* é a sessão do cofre, e perguntar isso já sabendo o `user_id` seria circular. O isolamento se mantém porque o login apaga as sessões anteriores: existe no máximo uma linha. A alternativa (decodificar o JWT) faria o app confiar no conteúdo de um token que quem valida é o Supabase.
+3. **`userId` virou função em `WorkspaceService` e nos handlers IPC** — a identidade deixou de ser fixa (local antes do login, sessão depois). Capturar a string no boot congelaria o escopo da auditoria no usuário local para sempre.
+4. **Teardown do E2E usa `app.exit()`, não `close()` nem `quit()`** — os dois travam, por comportamento correto do produto: o app vive no tray (`window-all-closed` vazio, SPEC-02) e os timers de rotação do `winston-daily-rotate-file` seguram o event loop no `will-quit`. Registrado em `docs/TESTING.md`.
 
 ### Fatia 04 — Modelo de dados mínimo + AuditEvent stub (`docs/spec/spec-fundacao-04-dados-audit.md`)
 
@@ -203,3 +209,4 @@ Ordem: MVP-002 (fundação de execução) → **MVP-003** ([#10](https://github.
 | 2026-07-22 | MVP-001 · F06 Observabilidade e Logging (#8) | [#27](https://github.com/RodReis/rrb-jarvisOS/pull/27) | Regras 49 (87.2%), **Banco 8 (85.5%)**, Tela 13 (97.6%). A categoria **Banco deixa de estar vazia antes da F04**: os testes de integração do logger tocam disco real (arquivo temporário, teardown por teste), que é exatamente o que a categoria mede — o `TESTING.md` §8 previa SQLite como primeiro caso, mas a régua é "integração com storage local", não "SQLite". Verificado também no app real: os três arquivos nascem em `userData/logs` e o registro do renderer chega ao disco. |
 | 2026-07-22 | MVP-001 · F04 Dados + AuditEvent (#5) **e** F02 AppShell/workspaces (#3) | [#28](https://github.com/RodReis/rrb-jarvisOS/pull/28) | Regras 78 (86.6%), Banco 32 (89.5%), Tela 16 (98.5%). Duas fatias no mesmo PR por decisão do PI: o critério 4 da SPEC-04 exige `AuditEvent` de `workspace-switch`, cujo fluxo nasce na F02. Carimbo pela issue do primeiro `refs` (#5), como o CI extrai. Verificado no app real: schema v1, 2 triggers ativos, chave de auditoria cifrada por DPAPI no disco. **F03 não entrou** — bloqueada por credenciais (ver a seção da fatia). |
 | 2026-07-22 | MVP-001 · F05 Settings mínimo (#6) | [#29](https://github.com/RodReis/rrb-jarvisOS/pull/29) | Regras 83 (84.0%), Banco 45 (89.6%), Tela 22 (95.5%). Fecha o MVP-001 **exceto a F03**. Primeira migration incremental do projeto (v1 → v2) exercitada sobre banco real com dado gravado — o log registrou `Migrations aplicadas {"quantidade":1}` e o perfil sobreviveu. Corrigiu um bug latente da F04: o upsert do perfil sobrescrevia `locale`/`theme` a cada boot. |
+| 2026-07-22 | MVP-001 · F03 Autenticação Google local-first (#4) | [#30](https://github.com/RodReis/rrb-jarvisOS/pull/30) | Regras 92 (79.6%), Banco 60 (87.0%), Tela 33 (93.5%) — **185 testes** contando os 3 E2E. **Fecha o MVP-001 (6/6 entregues).** Desbloqueada no mesmo dia, quando o PI criou as credenciais. A **categoria E2E deixa de contar 0**: o Playwright-Electron sobe o app empacotado e prova, com preload e IPC reais, que o shell não monta sem sessão e que a ponte não expõe caminho até o token. Dois achados de ambiente custaram tempo e ficaram registrados: `ELECTRON_RUN_AS_NODE` herdado do shell faz o Electron subir como Node puro (erro se disfarça de falha de bundle), e `close()`/`quit()` travam o teardown — o app vive no tray e os timers do `winston-daily-rotate-file` seguram o event loop. |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -8,14 +8,13 @@ Atualizado em: **2026-07-22**. Mantido pelo Code a cada entrega (junto com `DEVE
 
 | Issue | Fatia | MVP | Spec | Índice |
 |---|---|---|---|---|
-| [#4](https://github.com/RodReis/rrb-jarvisOS/issues/4) | 03 Auth Google local-first | MVP-001 (#1) | `spec-fundacao-03-auth-google.md` | F03 |
+| [#15](https://github.com/RodReis/rrb-jarvisOS/issues/15) | 01 Supabase local + ambiente de sync | MVP-002 (#9) | `spec-execucao-local-01-supabase-local.md` | M2-F01 |
 | [#11](https://github.com/RodReis/rrb-jarvisOS/issues/11) | 02 Policy Engine mínimo (classificação) | MVP-002 (#9) | `spec-execucao-local-02-policy-engine.md` | M2-F02 |
 | [#12](https://github.com/RodReis/rrb-jarvisOS/issues/12) | 03 Diretórios permitidos (allowlist) | MVP-002 (#9) | `spec-execucao-local-03-allowlist-diretorios.md` | M2-F03 |
 | [#13](https://github.com/RodReis/rrb-jarvisOS/issues/13) | 04 Registro de workflows + automações | MVP-002 (#9) | `spec-execucao-local-04-registro-workflows.md` | M2-F04 |
 | [#14](https://github.com/RodReis/rrb-jarvisOS/issues/14) | 05 Motor de execução simulado | MVP-002 (#9) | `spec-execucao-local-05-execucao-simulada.md` | M2-F05 |
-| [#15](https://github.com/RodReis/rrb-jarvisOS/issues/15) | 01 Supabase local + ambiente de sync | MVP-002 (#9) | `spec-execucao-local-01-supabase-local.md` | M2-F01 |
 
-> **[#4](https://github.com/RodReis/rrb-jarvisOS/issues/4) — F03 está BLOQUEADA**, não apenas na fila: depende de credenciais que só o PI pode criar (projeto Supabase de dev + cliente OAuth do Google Cloud). O `.env.example` na raiz lista as variáveis e onde obter cada uma. Sem elas, os critérios de login real, relançamento offline, token cifrado e E2E são inverificáveis. A infra que ela consome já está entregue na F04.
+> **`proplan:next` = [#15](https://github.com/RodReis/rrb-jarvisOS/issues/15)** (M2-F01, Supabase local): cabeça da fila do MVP-002 e independente das demais fatias dele. A F03 (#4), que ocupava o marcador enquanto estava bloqueada, foi **entregue em 2026-07-22** — o PI criou as credenciais e ela saiu no mesmo dia.
 
 > A Fatia 06 saiu como **#8** (o número 7 já estava ocupado). Sub-issue do épico #1; assignee PI.
 
@@ -27,6 +26,7 @@ Atualizado em: **2026-07-22**. Mantido pelo Code a cada entrega (junto com `DEVE
 | [#5](https://github.com/RodReis/rrb-jarvisOS/issues/5) | 04 Dados mínimos + AuditEvent | MVP-001 (#1) | `spec-fundacao-04-dados-audit.md` | F04 | [#28](https://github.com/RodReis/rrb-jarvisOS/pull/28) |
 | [#3](https://github.com/RodReis/rrb-jarvisOS/issues/3) | 02 AppShell e WorkspaceSwitcher | MVP-001 (#1) | `spec-fundacao-02-appshell-workspaces.md` | F02 | [#28](https://github.com/RodReis/rrb-jarvisOS/pull/28) |
 | [#6](https://github.com/RodReis/rrb-jarvisOS/issues/6) | 05 Settings mínimo | MVP-001 (#1) | `spec-fundacao-05-settings.md` | F05 | [#29](https://github.com/RodReis/rrb-jarvisOS/pull/29) |
+| [#4](https://github.com/RodReis/rrb-jarvisOS/issues/4) | 03 Auth Google local-first | MVP-001 (#1) | `spec-fundacao-03-auth-google.md` | F03 | [#30](https://github.com/RodReis/rrb-jarvisOS/pull/30) |
 
 > **04 e 02 saíram no mesmo PR**, por decisão do PI (2026-07-22): o critério 4 da SPEC-04 exige `AuditEvent` de `workspace-switch`, cujo fluxo nasce na F02 — separá-las exigiria um stub que a F02 jogaria fora. O critério 4 fica **parcialmente atendido**: `workspace-switch` está provado ponta a ponta; `login`/`logout`/`login-offline-reuse` têm o tipo no contrato e o fluxo nasce na F03.
 
@@ -65,7 +65,7 @@ Não há catálogo numérico `SPEC-nnn` para o MVP-001: as specs são identifica
 
 | MVP | Issue | Estado | Fatias fechadas |
 |---|---|---|---|
-| MVP-001 Fundação | [#1](https://github.com/RodReis/rrb-jarvisOS/issues/1) | **5 das 6 fatias entregues** (#2, #3, #5, #6, #8). Resta só a **F03 (#4), bloqueada** por credenciais Supabase/Google — quando ela entrar, o épico fecha | 4 / 6 *(aceitas)* · **5 / 6 entregues** |
+| MVP-001 Fundação | [#1](https://github.com/RodReis/rrb-jarvisOS/issues/1) | **6 das 6 fatias entregues** (#2, #3, #4, #5, #6, #8). Nada mais em aberto no escopo — o épico fecha quando o PI aceitar as fatias entregues | 4 / 6 *(aceitas)* · **6 / 6 entregues** |
 | MVP-002 Execução local controlada (fundação) | [#9](https://github.com/RodReis/rrb-jarvisOS/issues/9) | épico criado; 5 fatias com spec **`aprovada-pi`** em Backlog (#11–#15) | 0 / 5 |
 | MVP-003 Design System da Plataforma (base única, 2 identidades) | [#16](https://github.com/RodReis/rrb-jarvisOS/issues/16) | épico criado; **8 fatias** em Backlog (#17–#24), todas com spec `aprovada-pi` | 0 / 8 |
 | MVP-004 Execução real (terminal + execução allowlisted) | [#10](https://github.com/RodReis/rrb-jarvisOS/issues/10) | renumerado de MVP-003 (título/rótulo atualizados + carimbo); 2 fatias lazy | 0 / 2 |
@@ -75,13 +75,14 @@ Não há catálogo numérico `SPEC-nnn` para o MVP-001: as specs são identifica
 
 ## Próximas ações
 
-1. **MVP-001 quase fechado** (2026-07-22): **5 das 6 fatias entregues** — F01 (#2), F06 (#8), F04 (#5), F02 (#3) e F05 (#6). Ordem executada: **01 → 06 → 04+02 → 05**. Resta a **F03 (#4)**, marcada com `proplan:next` mas **bloqueada**: depende de credenciais Supabase/Google que só o PI pode criar (ver ação 5). Enquanto isso, a fila do MVP-001 está vazia — o próximo trabalho desbloqueado é o **MVP-002** (#9), cuja F01 (#15) é independente das demais.
+1. **MVP-001 entregue por inteiro** (2026-07-22): **6 das 6 fatias** — F01 (#2), F06 (#8), F04 (#5), F02 (#3), F05 (#6) e F03 (#4). Ordem executada: **01 → 06 → 04+02 → 05 → 03**. A F03 destravou quando o PI criou as credenciais e saiu no mesmo dia. O `proplan:next` avançou para o **MVP-002** (#9), começando pela F01 (#15), que é independente das demais.
 2. ~~Resolver as "Perguntas ao PI" das specs do MVP-003~~ — **feito** (2026-07-21): as 8 specs estão `aprovada-pi`.
 3. ~~Renumerar #10 → MVP-004 e criar o épico MVP-003 + issues~~ — **feito** (2026-07-21): #10 retitulada MVP-004 (carimbo), épico **#16** criado, 8 filhas **#17–#24** em Backlog e vinculadas.
 4. **Code**: quando MVP-001/002 estiverem entregues, iniciar o MVP-003 pela F01 (#17); WIP = 1, na ordem F01 → F02 → (F03a/F03b/F05) → F04a → F04b → F06.
-5. **PI — desbloqueia a F03 (#4):** criar o projeto **Supabase de desenvolvimento** na nuvem (ADR-002) e o **cliente OAuth do Google Cloud** (tipo *Aplicativo para computador*, exigido pelo retorno via loopback), registrar o cliente no Supabase em Authentication → Providers → Google, e preencher o `.env` local. As quatro variáveis e onde obter cada uma estão no **`.env.example`** da raiz. Enquanto isso não existe, a F03 fica fora da fila — os critérios dela são inverificáveis sem um provedor de identidade real.
-6. **PI**: (opcional) decidir a adoção de numeração `SPEC-nnn`.
-7. **PI**: aceitar cada fatia (fechar issue + `proplan:finalizado`) só após PR mergeado.
+5. ~~**PI — desbloqueia a F03 (#4)**~~ — **feito** (2026-07-22): projeto Supabase de dev criado, cliente OAuth do Google Cloud registrado e `.env` preenchido. A fatia foi entregue no mesmo dia ([#30](https://github.com/RodReis/rrb-jarvisOS/pull/30)). *Nota:* o `GOOGLE_OAUTH_CLIENT_SECRET` do `.env` **não é consumido pelo app** — no desenho do ADR-002 quem fala com o Google é o Supabase, e o secret vive no painel dele. Decisão do PI: manter a variável sem uso.
+6. **Code**: iniciar o **MVP-002** pela F01 (#15), já marcada `proplan:next`. Ordem: 01 → 02 → 03 → 04 → 05 (a 05 depende de 02+03+04).
+7. **PI**: (opcional) decidir a adoção de numeração `SPEC-nnn`.
+8. **PI**: aceitar cada fatia (fechar issue + `proplan:finalizado`) só após PR mergeado. **Pendentes de aceite:** #2, #3, #5, #6 e #4 — com todas aceitas, o épico **#1 (MVP-001) pode fechar**.
 
 ## Roadmap macro
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -76,7 +76,7 @@ constante embutida no gerador.
 O mapeamento categoria→origem mora em **`test-report.config.json`** (raiz), não no código do
 gerador — assim o mesmo tooling cai em outro projeto só ajustando o mapa (reutilização, §7).
 
-### 3.1 E2E Electron: três armadilhas de ambiente (achados da Fatia 03)
+### 3.1 E2E Electron: armadilhas de ambiente (achados da Fatia 03)
 
 Custaram tempo real de diagnóstico e **não são bugs do app** — são consequências de
 comportamentos corretos dele. Quem for escrever ou depurar E2E aqui deve ler antes:
@@ -105,14 +105,32 @@ comportamentos corretos dele. Quem for escrever ou depurar E2E aqui deve ler ant
    perdido no meio da saída. O `ci.yml` roda `node node_modules/electron/install.js`
    (idempotente) logo após o `npm ci`.
 
+5. **No CI Linux, o `chrome-sandbox` do pacote npm não tem setuid.** O npm não preserva
+   permissões: o binário precisa de dono `root` e modo `4755`, senão o processo aborta no
+   boot com `FATAL:setuid_sandbox_host.cc` + `SIGTRAP` — que o Playwright reporta como
+   timeout de `firstWindow()`, porque o stderr do processo não chega ao reporter. Subir com
+   `--no-sandbox` está descartado: o sandbox é critério de aceite da SPEC-Fundacao-03. O
+   `ci.yml` faz `chown root:root` + `chmod 4755` antes dos testes.
+
+6. **No CI Linux, `safeStorage` não existe sem keyring.** O runner não tem D-Bus de sessão
+   nem secret service; o backend de senha do Chromium cai em `basic_text` e
+   `isEncryptionAvailable()` responde false. O boot então falha alto por desenho (ADR-004:
+   chave de auditoria nunca em claro no disco) e a janela não nasce — de novo, o E2E só vê
+   timeout de `firstWindow()`. O `ci.yml` instala `gnome-keyring` + `dbus-x11`, sobe um
+   D-Bus de sessão, destrava o keyring com senha vazia e exporta
+   `DBUS_SESSION_BUS_ADDRESS` + `XDG_CURRENT_DESKTOP=GNOME` (sem o desktop declarado o
+   Chromium nem tenta o libsecret). Afrouxar o código para o teste passaria exatamente
+   onde ele deveria provar a garantia.
+
 **O E2E exige build.** O Playwright sobe o app empacotado (`out/`), não o servidor de dev —
 rodá-lo sem `npm run build` testaria a versão anterior do código. O orquestrador
 (`scripts/test-report.mjs`) já faz o build antes de chamar o Playwright.
 
-**Padrão das quatro armadilhas:** nenhuma se apresenta como o que é. Falha de launch do
+**Padrão das armadilhas:** nenhuma se apresenta como o que é. Falha de launch do
 Electron no CI quase sempre reporta timeout ou "browser has been closed" — mensagens que
 apontam para o Playwright quando a causa está no ambiente. Antes de mexer no teste, confira
-binário, display e processos remanescentes.
+binário, display, sandbox, keyring e processos remanescentes — e leia o stderr cru do
+processo principal (subindo o app fora do Playwright), porque o reporter o engole.
 
 > **Por que Vitest único, e não Jest+projects como no proplan.** O jarvis é Vite-nativo; Vitest é
 > o runner natural (mesma config, mesmo transform). O relatório `--json` do Vitest é

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -97,9 +97,22 @@ comportamentos corretos dele. Quem for escrever ou depurar E2E aqui deve ler ant
    é a instância única funcionando. Ao investigar falha de launch, limpe primeiro:
    `taskkill //F //IM electron.exe`.
 
+4. **No CI, baixe o binário do Electron antes dos testes.** O `postinstall` do projeto é
+   `electron-rebuild` (compila o `better-sqlite3`) e **não** baixa o binário. Sem um passo
+   explícito, o download de ~100 MB acontece dentro do primeiro teste e estoura os 30s do
+   `firstWindow()`. O sintoma engana de novo: `Timeout exceeded while waiting for event
+   "window"`, sem erro de biblioteca — a única pista é um `Downloading Electron binary...`
+   perdido no meio da saída. O `ci.yml` roda `node node_modules/electron/install.js`
+   (idempotente) logo após o `npm ci`.
+
 **O E2E exige build.** O Playwright sobe o app empacotado (`out/`), não o servidor de dev —
 rodá-lo sem `npm run build` testaria a versão anterior do código. O orquestrador
 (`scripts/test-report.mjs`) já faz o build antes de chamar o Playwright.
+
+**Padrão das quatro armadilhas:** nenhuma se apresenta como o que é. Falha de launch do
+Electron no CI quase sempre reporta timeout ou "browser has been closed" — mensagens que
+apontam para o Playwright quando a causa está no ambiente. Antes de mexer no teste, confira
+binário, display e processos remanescentes.
 
 > **Por que Vitest único, e não Jest+projects como no proplan.** O jarvis é Vite-nativo; Vitest é
 > o runner natural (mesma config, mesmo transform). O relatório `--json` do Vitest é

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -66,13 +66,40 @@ constante embutida no gerador.
 - `banco`  → `src/main/**/*.int-spec.ts` **+** `tests/**/*.int-spec.ts` — integração com o storage
   local (SQLite) num arquivo temporário, com teardown por teste.
 
-**Renderer (`src/renderer`, `e2e`):**
+**Renderer (`src/renderer`, `tests/e2e`):**
 
 - Componente → Vitest + Testing Library (jsdom): `src/renderer/**/*.test.tsx`.
-- E2E → Playwright-Electron: `e2e/**/*.spec.ts`.
+- E2E → Playwright-Electron: `tests/e2e/**/*.e2e.ts` (config em `playwright.config.ts`).
+  O sufixo é `.e2e.ts` e não `.spec.ts` — este último já pertence à categoria *regras* no
+  `include` do Vitest, e a mesma extensão nas duas faria o Vitest tentar rodar o E2E.
 
 O mapeamento categoria→origem mora em **`test-report.config.json`** (raiz), não no código do
 gerador — assim o mesmo tooling cai em outro projeto só ajustando o mapa (reutilização, §7).
+
+### 3.1 E2E Electron: três armadilhas de ambiente (achados da Fatia 03)
+
+Custaram tempo real de diagnóstico e **não são bugs do app** — são consequências de
+comportamentos corretos dele. Quem for escrever ou depurar E2E aqui deve ler antes:
+
+1. **Encerre com `app.exit(0)`, nunca com `close()` ou `quit()`.** Os dois travam o teardown
+   e deixam a janela aberta na tela de quem roda a suíte. `close()` espera o processo morrer,
+   mas o app **vive no tray** (`window-all-closed` é deliberadamente vazio, SPEC-02); `quit()`
+   dispara `will-quit`, que fecha o logger, e os timers de rotação do
+   `winston-daily-rotate-file` seguram o event loop. `exit()` ignora handles pendentes e
+   encerra em ~200ms. É seguro porque o `userData` do teste é temporário e descartável.
+2. **`ELECTRON_RUN_AS_NODE` herdado do shell quebra o launch.** Com a variável setada, o
+   Electron sobe como Node puro e o erro aparece como `does not provide an export named
+   BrowserWindow` — parece falha de bundle e não é. O `beforeEach` do E2E remove a variável
+   do ambiente do processo filho, para o teste não depender de quem o executa.
+3. **Processos `electron.exe` remanescentes fazem o launch falhar em silêncio.** O
+   `requestSingleInstanceLock()` (SPEC-02) derruba cada nova instância no boot, e o Playwright
+   reporta `Target page, context or browser has been closed` — que parece erro de conexão, mas
+   é a instância única funcionando. Ao investigar falha de launch, limpe primeiro:
+   `taskkill //F //IM electron.exe`.
+
+**O E2E exige build.** O Playwright sobe o app empacotado (`out/`), não o servidor de dev —
+rodá-lo sem `npm run build` testaria a versão anterior do código. O orquestrador
+(`scripts/test-report.mjs`) já faz o build antes de chamar o Playwright.
 
 > **Por que Vitest único, e não Jest+projects como no proplan.** O jarvis é Vite-nativo; Vitest é
 > o runner natural (mesma config, mesmo transform). O relatório `--json` do Vitest é
@@ -201,10 +228,11 @@ Dispara em **todo pull request** para `main`. Job `test`:
 - **Passos:**
   1. `npm ci`.
   2. **Domínio/main:** `vitest run` das categorias `regras` e `banco` com `--coverage --reporter=json`.
-  3. **Renderer (componente):** `vitest run` (jsdom) com `--coverage --reporter=json`. **O E2E
-     Playwright-Electron entra na Fatia 03** — a SPEC-Fundacao-01 deixa Playwright fora do
-     bootstrap. Quando entrar: `playwright install --with-deps chromium` → `xvfb-run playwright
-     test --reporter=json` (Electron abre janela; no Linux do CI precisa de display virtual).
+  3. **Renderer (componente):** `vitest run` (jsdom) com `--coverage --reporter=json`.
+  3b. **E2E:** ativo desde a **Fatia 03** (entregue em 2026-07-22). `npm run build` →
+     `xvfb-run playwright test` (o Electron abre janela: no Linux do CI precisa de display
+     virtual). O reporter JSON e o caminho de saída vivem no `playwright.config.ts`. Ver §3.1
+     para as armadilhas de ambiente antes de depurar falha de launch no CI.
   4. `npm run test:report` → escreve a tabela em **`$GITHUB_STEP_SUMMARY`** (aba do run) **e**
      publica/atualiza um **comentário fixo no PR** (sticky comment).
   5. `npm run test:report:check` → **falha se `reports/TESTS.md` divergir** de uma execução limpa.
@@ -246,9 +274,9 @@ Para o Code implementar **na Fatia 01** e o PI conferir:
       blob da base do PR como baseline — nunca o próprio arquivo.
 - [ ] O gerador tem self-check próprio no CI (`npm run test:report:selfcheck`), incluindo o caso CRLF.
 - [ ] Cobertura é **reportada**, não barra merge.
-- [ ] **Fatia 01:** `src/renderer` tem **Vitest + Testing Library**; a categoria "Tela"
-      (componente) não fica vazia. **Playwright-Electron (E2E) entra na Fatia 03**; **Banco**
-      (SQLite) na Fatia 04 — até lá essas categorias podem ter contagem 0 sem invalidar o relatório.
+- [x] **Fatia 01:** `src/renderer` tem **Vitest + Testing Library**; a categoria "Tela"
+      (componente) não fica vazia. **Banco** (SQLite) entrou na F04 e o **Playwright-Electron
+      (E2E) na F03** (2026-07-22) — nenhuma das três categorias conta 0 desde então.
 - [ ] `reports/TESTS.md` **não** está sob `docs/`.
 - [ ] A decisão está registrada como **ADR-003** (`docs/adr/adr-003-relatorio-testes-evidencia.md`).
 
@@ -257,9 +285,10 @@ Para o Code implementar **na Fatia 01** e o PI conferir:
 - **Gerenciador/comando:** `npm run test:report` (a **SPEC-Fundacao-01 fixou npm**; o `pnpm` do
   proplan não se aplica — o `electron-vite` é single-package, sem monorepo).
 - **Runner:** **Vitest** (unidade + componente) e **Playwright-Electron** (E2E). Sem Jest.
-- **Playwright no CI:** **a partir da Fatia 03** (quando o E2E entra), roda **sempre** enquanto a
-  suíte for pequena; com `xvfb-run` (Electron precisa de display). Reavaliar (label/condicional) se
-  o tempo de CI incomodar.
+- **Playwright no CI:** **ativo desde a Fatia 03** (2026-07-22). Roda **sempre** enquanto a suíte
+  for pequena (3 testes, ~2s local); com `xvfb-run` (Electron precisa de display). Reavaliar
+  (label/condicional) se o tempo de CI incomodar. `workers: 1` é obrigatório, não preferência: o
+  `requestSingleInstanceLock()` (SPEC-02) faz instâncias paralelas se derrubarem entre si.
 - **Storage do "Banco":** o setup concreto (arquivo temp, migrations de teste) **finaliza quando a
   SPEC-Fundacao-04 decidir SQLite vs JSON**. A metodologia (3 categorias, evidência de máquina,
   anti-drift) independe dessa escolha.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
+        "@supabase/supabase-js": "^2.110.8",
         "better-sqlite3": "^13.0.1",
         "electron-log": "^5.4.4",
         "i18next": "^26.3.6",
@@ -21,6 +22,7 @@
         "@electron-toolkit/tsconfig": "^2.0.0",
         "@electron/rebuild": "^4.2.0",
         "@eslint/js": "^9.39.5",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/vite": "^4.3.3",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1458,6 +1460,22 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1870,6 +1888,90 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.110.8",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.8.tgz",
+      "integrity": "sha512-TQ5neTUDX2C2WmyYa03yGhLMkhdE/SkHXtK8/qxO/APUy3rsymsJCBP48p4jcN6iO2G0ow6RRexQd2mX+dSyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.110.8",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.8.tgz",
+      "integrity": "sha512-5yB9TLYzvv2oSQxwb0gamEvIAsuH66pVt7AM/pz03S7wN6ehD34GNgbShrccetqPedXQSz7e/1hAJ9NeEhoZVg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.110.8",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.8.tgz",
+      "integrity": "sha512-QeRROxl1PpOZw5Jzi7BwdN9icsycMrLlCCvsjS0hYLW+nZoaT46zdagz/glJirj8jHF4jSd5Jyipuae2cBClCw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.110.8",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.8.tgz",
+      "integrity": "sha512-mwX7ituX6O31fLf+0g65rpLlNxqgnMaPltPsQwzox6jfmbfVl3tCxXrfr3HEsQcCRjpjuJG1+A0vFzP1yVjKHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.110.8",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.8.tgz",
+      "integrity": "sha512-CcfhkZFBLxsthgUabZKxwfsoXdrikIGsL3LsGoV3FZTqCMx/s1y49taT4jT/oya5+1IuB0sFFHw6pF0o0iJniQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.110.8",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.8.tgz",
+      "integrity": "sha512-E5qzoe74zhJRv4wRcbO9eMYzeQDb/+h6c603pL8shcxLGBjTKsIF7XXj05IcNj23TLDgJN1WkMw7mwAPyu5dZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.110.8",
+        "@supabase/functions-js": "2.110.8",
+        "@supabase/postgrest-js": "2.110.8",
+        "@supabase/realtime-js": "2.110.8",
+        "@supabase/storage-js": "2.110.8"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.3",
@@ -4067,6 +4169,15 @@
         }
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5167,6 +5278,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.22",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
@@ -5807,6 +5965,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@electron-toolkit/tsconfig": "^2.0.0",
     "@electron/rebuild": "^4.2.0",
     "@eslint/js": "^9.39.5",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/vite": "^4.3.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
@@ -57,6 +58,7 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.110.8",
     "better-sqlite3": "^13.0.1",
     "electron-log": "^5.4.4",
     "i18next": "^26.3.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,6 +23,12 @@ export default defineConfig({
   // falha real — que reprova nas duas tentativas.
   retries: process.env.CI ? 1 : 0,
   timeout: 60_000,
+  expect: {
+    // O runner do CI é mais lento que a máquina de dev no primeiro boot do Electron
+    // (cold start, disco compartilhado). 15s evita falso vermelho sem esconder trava
+    // real — o timeout do teste (60s) continua sendo o limite que importa.
+    timeout: 15_000
+  },
   reporter: [
     ['list'],
     // Caminho que o `test-report.config.json` já declara para a categoria Tela.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from '@playwright/test'
+
+/**
+ * E2E Playwright-Electron (ADR-003; SPEC-Fundacao-03, critério 9).
+ *
+ * Complementa a categoria "Tela" do `test-report.config.json`, que já esperava um
+ * `tela-playwright.json` — os testes de componente rodam em jsdom pelo Vitest; aqui sobe
+ * o **app Electron de verdade**, que é a única forma de provar que preload, IPC e janela
+ * funcionam juntos.
+ *
+ * Fora de escopo deliberadamente: o login real contra o Google. Automatizar a tela de
+ * consentimento de um provedor externo produz teste que quebra quando o Google muda o HTML,
+ * e o que a spec pede é provar o **fluxo do app** — por isso o provedor é interceptado no
+ * loopback (ver `tests/e2e/login.e2e.ts`).
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: /.*\.e2e\.ts/,
+  // Electron sobe um processo por teste: paralelismo aqui disputa o mesmo `userData`.
+  workers: 1,
+  fullyParallel: false,
+  // Um retry cobre a flutuação de boot do Electron em máquina carregada, sem mascarar
+  // falha real — que reprova nas duas tentativas.
+  retries: process.env.CI ? 1 : 0,
+  timeout: 60_000,
+  reporter: [
+    ['list'],
+    // Caminho que o `test-report.config.json` já declara para a categoria Tela.
+    ['json', { outputFile: 'reports/.raw/tela-playwright.json' }]
+  ]
+})

--- a/reports/TESTS.md
+++ b/reports/TESTS.md
@@ -12,9 +12,9 @@ Totais da última execução (regenerado, não acumulado):
 
 | Data | Issue | SPEC | Categoria | Testes | Pass | Falha | Cobertura % | PR | Link PR |
 |------|-------|------|-----------|-------:|-----:|------:|------------:|----:|--------|
-| — | — | — | Regras de Negócio | 83 | 83 | 0 | 84.0 | — | — |
-| — | — | — | Banco | 45 | 45 | 0 | 89.6 | — | — |
-| — | — | — | Tela | 22 | 22 | 0 | 95.5 | — | — |
+| — | — | — | Regras de Negócio | 92 | 92 | 0 | 79.6 | — | — |
+| — | — | — | Banco | 60 | 60 | 0 | 87.0 | — | — |
+| — | — | — | Tela | 33 | 33 | 0 | 93.5 | — | — |
 
 ## Histórico por entrega
 
@@ -34,3 +34,6 @@ Append-only — linhas de entregas passadas são imutáveis.
 | 2026-07-22 | #6 | spec-fundacao-05-settings | Regras de Negócio | 83 | 83 | 0 | 84.0 | #29 | [#29](https://github.com/RodReis/rrb-jarvisOS/pull/29) |
 | 2026-07-22 | #6 | spec-fundacao-05-settings | Banco | 45 | 45 | 0 | 89.6 | #29 | [#29](https://github.com/RodReis/rrb-jarvisOS/pull/29) |
 | 2026-07-22 | #6 | spec-fundacao-05-settings | Tela | 22 | 22 | 0 | 95.5 | #29 | [#29](https://github.com/RodReis/rrb-jarvisOS/pull/29) |
+| 2026-07-22 | #4 | spec-fundacao-03-auth-google | Regras de Negócio | 92 | 92 | 0 | 79.6 | #30 | [#30](https://github.com/RodReis/rrb-jarvisOS/pull/30) |
+| 2026-07-22 | #4 | spec-fundacao-03-auth-google | Banco | 60 | 60 | 0 | 87.0 | #30 | [#30](https://github.com/RodReis/rrb-jarvisOS/pull/30) |
+| 2026-07-22 | #4 | spec-fundacao-03-auth-google | Tela | 33 | 33 | 0 | 93.5 | #30 | [#30](https://github.com/RodReis/rrb-jarvisOS/pull/30) |

--- a/scripts/test-report.mjs
+++ b/scripts/test-report.mjs
@@ -66,12 +66,20 @@ function runVitestProject(project, rawName, coverageDir) {
 if (!noRun) {
   mkdirSync(RAW, { recursive: true })
 
-  // As 3 categorias do ADR-003. `banco` nasce vazia (SQLite entra na Fatia 04) e
-  // a parte Playwright de `tela` entra na Fatia 03 — ambas contam 0 sem invalidar
-  // o relatório (docs/TESTING.md §8).
+  // As 3 categorias do ADR-003. A parte Playwright de `tela` passou a existir na
+  // Fatia 03 (SPEC-Fundacao-03, critério 9) — antes contava 0 sem invalidar o
+  // relatório (docs/TESTING.md §8).
   runVitestProject('regras', 'regras.json', 'regras')
   runVitestProject('banco', 'banco.json', 'banco')
   runVitestProject('tela', 'tela-vitest.json', 'tela')
+
+  // E2E Electron. Exige o build (`out/`) — o Playwright sobe o app empacotado, não o
+  // servidor de dev, então rodá-lo sem build testaria a versão anterior do código.
+  run('npm', ['run', 'build'])
+  // O reporter JSON e o caminho de saída vêm do `playwright.config.ts`, que já grava
+  // em `reports/.raw/tela-playwright.json` — o mesmo caminho que o
+  // `test-report.config.json` declara para a categoria Tela.
+  run('npx', ['playwright', 'test'])
 }
 
 const entry = selfcheck ? 'scripts/gen-test-report.selfcheck.mjs' : 'scripts/gen-test-report.mjs'

--- a/src/main/auth/auth-service.int-spec.ts
+++ b/src/main/auth/auth-service.int-spec.ts
@@ -1,0 +1,379 @@
+/**
+ * Fluxo de autenticação ponta a ponta contra o SQLite real (categoria "Banco").
+ *
+ * Prova os critérios 2, 3, 5 e 8 da SPEC-Fundacao-03 sem rede: o Supabase entra dublado,
+ * porque o que está sob teste é o comportamento **local-first** — o que o app faz com a
+ * sessão depois que o provedor respondeu, que é justamente o que precisa valer offline.
+ *
+ * O que não está aqui: o fluxo feliz de ponta a ponta com janela real, que é o E2E
+ * Playwright-Electron (critério 9), e a cifra do `safeStorage`, exercitada em
+ * `token-vault.spec.ts` — aqui o cofre é o dublê em memória.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Database as Db } from 'better-sqlite3'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { OFFLINE_SESSION_MAX_DAYS, type AuthSnapshot } from '@shared/contracts/auth'
+
+const logCat = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+vi.mock('../logging/logger', () => ({
+  log: new Proxy({}, { get: () => logCat }),
+  setCurrentWorkspace: vi.fn()
+}))
+
+const { openDatabase } = await import('../storage/database')
+const { AuditRepository } = await import('../storage/audit-repository')
+const { SessionRepository, UserProfileRepository } = await import('../storage/repositories')
+const { AuthService } = await import('./auth-service')
+const { startLoopbackServer } = await import('./loopback-server')
+import type { StoredTokens, TokenVault } from './token-vault'
+
+const MS_POR_DIA = 24 * 60 * 60 * 1000
+
+/** Tokens de teste. Valores reconhecíveis para o teste de redaction poder procurá-los. */
+const ACCESS_TOKEN = 'access-token-secreto-abc123'
+const REFRESH_TOKEN = 'refresh-token-secreto-xyz789'
+
+const SESSAO_SUPABASE = {
+  access_token: ACCESS_TOKEN,
+  refresh_token: REFRESH_TOKEN,
+  expires_at: 1_800_000_000,
+  user: {
+    id: 'u-google-1',
+    email: 'rodrigo@example.com',
+    user_metadata: { full_name: 'Rodrigo Reis' }
+  }
+}
+
+/** Cofre em memória: o teste da cifra real vive em `token-vault.spec.ts`. */
+class CofreEmMemoria implements TokenVault {
+  private tokens: StoredTokens | undefined
+
+  read(): StoredTokens | undefined {
+    return this.tokens
+  }
+  write(tokens: StoredTokens): void {
+    this.tokens = tokens
+  }
+  clear(): void {
+    this.tokens = undefined
+  }
+}
+
+let dir: string
+let db: Db
+let audit: InstanceType<typeof AuditRepository>
+let profiles: InstanceType<typeof UserProfileRepository>
+let sessions: InstanceType<typeof SessionRepository>
+let vault: CofreEmMemoria
+let agora: Date
+let transicoes: unknown[]
+
+/** Dublê do Supabase que devolve uma sessão válida sem tocar a rede. */
+function supabaseDublado(overrides: Record<string, unknown> = {}): never {
+  return {
+    auth: {
+      signInWithOAuth: vi.fn().mockResolvedValue({
+        data: { url: 'https://accounts.google.com/o/oauth2/v2/auth?fake=1' },
+        error: null
+      }),
+      exchangeCodeForSession: vi.fn().mockResolvedValue({
+        data: { session: SESSAO_SUPABASE },
+        error: null
+      }),
+      signOut: vi.fn().mockResolvedValue({ error: null }),
+      ...overrides
+    }
+  } as never
+}
+
+function criarServico(supabase = supabaseDublado()): InstanceType<typeof AuthService> {
+  return new AuthService({
+    supabase,
+    vault,
+    audit,
+    profiles,
+    sessions,
+    openExternal: vi.fn().mockResolvedValue(undefined),
+    onChange: (snapshot) => transicoes.push(snapshot),
+    now: () => agora
+  })
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'jarvis-auth-'))
+  db = openDatabase(join(dir, 'teste.db'))
+  audit = new AuditRepository(db, 'chave-de-teste')
+  profiles = new UserProfileRepository(db)
+  sessions = new SessionRepository(db)
+  vault = new CofreEmMemoria()
+  agora = new Date('2026-07-22T12:00:00.000Z')
+  transicoes = []
+  logCat.info.mockClear()
+  logCat.warn.mockClear()
+  logCat.error.mockClear()
+})
+
+afterEach(() => {
+  db.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+/** Grava a sessão como um login bem-sucedido teria feito, sem passar pelo OAuth. */
+function semearSessaoAtiva(diasAtras = 0): void {
+  const autenticadoEm = new Date(agora.getTime() - diasAtras * MS_POR_DIA)
+  const expiraEm = new Date(autenticadoEm.getTime() + OFFLINE_SESSION_MAX_DAYS * MS_POR_DIA)
+
+  profiles.save({
+    id: SESSAO_SUPABASE.user.id,
+    name: 'Rodrigo Reis',
+    email: SESSAO_SUPABASE.user.email,
+    locale: 'pt-BR',
+    theme: 'sistema'
+  })
+
+  sessions.save({
+    id: 'sessao-1',
+    user_id: SESSAO_SUPABASE.user.id,
+    expires_at: expiraEm.toISOString(),
+    last_online_auth_at: autenticadoEm.toISOString(),
+    created_at: autenticadoEm.toISOString()
+  })
+
+  vault.write({
+    accessToken: ACCESS_TOKEN,
+    refreshToken: REFRESH_TOKEN,
+    expiresAt: SESSAO_SUPABASE.expires_at
+  })
+}
+
+describe('AuthService — login (critérios 1 e 5)', () => {
+  /**
+   * Dirige o fluxo real: dispara `login()`, espera o navegador ser "aberto" e então bate
+   * no loopback com o código, como o Google faria. Exercita servidor, troca e persistência
+   * de ponta a ponta — só o Supabase é dublado.
+   */
+  async function loginDirigido(query: string): Promise<AuthSnapshot> {
+    // O `redirectTo` que o serviço passa ao Supabase é a porta do loopback; guardá-lo é
+    // o que permite ao dublê do navegador bater de volta como o Google faria.
+    let redirectCapturado = ''
+
+    const abrirNavegador = vi.fn(async () => {
+      await fetch(`${redirectCapturado}/${query}`)
+    })
+
+    const supabase = supabaseDublado({
+      signInWithOAuth: vi.fn((opcoes: { options: { redirectTo: string } }) => {
+        redirectCapturado = opcoes.options.redirectTo
+        return Promise.resolve({
+          data: { url: `https://accounts.google.com/o/oauth2/v2/auth?fake=1` },
+          error: null
+        })
+      })
+    })
+
+    const servico = new AuthService({
+      supabase,
+      vault,
+      audit,
+      profiles,
+      sessions,
+      openExternal: abrirNavegador,
+      onChange: (snapshot) => transicoes.push(snapshot),
+      now: () => agora
+    })
+
+    return await servico.login()
+  }
+
+  it('conclui o login, persiste a sessão e expõe nome e e-mail', async () => {
+    const snapshot = await loginDirigido('?code=codigo-de-teste')
+
+    expect(snapshot.state).toBe('ativo')
+    expect(snapshot.profile?.name).toBe('Rodrigo Reis')
+    expect(snapshot.profile?.email).toBe('rodrigo@example.com')
+
+    // Sessão e cofre gravados: é o que faz o relançamento offline funcionar depois.
+    expect(sessions.findActive(SESSAO_SUPABASE.user.id)).toBeDefined()
+    expect(vault.read()?.refreshToken).toBe(REFRESH_TOKEN)
+  })
+
+  it('audita o login com o user_id da sessão (critério 5)', async () => {
+    await loginDirigido('?code=codigo-de-teste')
+
+    const eventos = audit.list(SESSAO_SUPABASE.user.id)
+    const login = eventos.find((e) => e.type === 'login')
+
+    expect(login).toBeDefined()
+    expect(login?.user_id).toBe(SESSAO_SUPABASE.user.id)
+    expect(login?.created_at).toBeTruthy()
+    // Auditoria não é lugar de credencial: o payload não pode carregar o token.
+    expect(JSON.stringify(login?.payload)).not.toContain(ACCESS_TOKEN)
+  })
+
+  it('a janela offline expira 30 dias após o login (ADR-001)', async () => {
+    const snapshot = await loginDirigido('?code=codigo-de-teste')
+
+    const esperado = new Date(agora.getTime() + OFFLINE_SESSION_MAX_DAYS * MS_POR_DIA)
+    expect(snapshot.expiresAt).toBe(esperado.toISOString())
+  })
+
+  it('vira erro com mensagem de UI quando o provedor recusa (critério 6)', async () => {
+    const snapshot = await loginDirigido('?error=access_denied')
+
+    expect(snapshot.state).toBe('erro')
+    expect(snapshot.mensagem).toBeTruthy()
+    // Sem stack trace e sem jargão do provedor vazando para a tela.
+    expect(snapshot.mensagem).not.toContain('access_denied')
+    expect(snapshot.mensagem).not.toMatch(/\bat\s+\w+\./)
+  })
+})
+
+describe('AuthService — relançamento offline (critério 2)', () => {
+  it('entra direto com sessão cacheada válida, sem tocar a rede', async () => {
+    semearSessaoAtiva(3)
+
+    // Supabase que estoura se for chamado: prova que a restauração é 100% local.
+    const service = criarServico(
+      supabaseDublado({
+        signInWithOAuth: vi.fn().mockRejectedValue(new Error('não deveria chamar a rede')),
+        exchangeCodeForSession: vi.fn().mockRejectedValue(new Error('não deveria chamar a rede'))
+      })
+    )
+
+    const snapshot = await service.restaurar()
+
+    expect(snapshot.state).toBe('ativo')
+    expect(snapshot.profile?.email).toBe('rodrigo@example.com')
+  })
+
+  it('audita login-offline-reuse ao reusar a sessão (critério 5)', async () => {
+    semearSessaoAtiva(3)
+    await criarServico().restaurar()
+
+    const eventos = audit.list(SESSAO_SUPABASE.user.id)
+    expect(eventos.map((e) => e.type)).toContain('login-offline-reuse')
+  })
+
+  it('exige novo login depois dos 30 dias, mesmo com token no disco', async () => {
+    // Autenticado há 31 dias: fora da janela do ADR-001.
+    semearSessaoAtiva(OFFLINE_SESSION_MAX_DAYS + 1)
+
+    const snapshot = await criarServico().restaurar()
+
+    expect(snapshot.state).toBe('sessao-expirada')
+    // O cofre é limpo: sessão vencida não deixa credencial de longa duração no disco.
+    expect(vault.read()).toBeUndefined()
+  })
+
+  it('mantém a sessão no último dia da janela (limite inclusivo)', async () => {
+    semearSessaoAtiva(OFFLINE_SESSION_MAX_DAYS - 1)
+
+    const snapshot = await criarServico().restaurar()
+
+    expect(snapshot.state).toBe('ativo')
+  })
+
+  it('trata cofre sem metadados de sessão como deslogado', async () => {
+    // Cofre com token mas sem linha em `session`: estado inconsistente.
+    vault.write({ accessToken: 'a', refreshToken: 'b', expiresAt: 1 })
+
+    const snapshot = await criarServico().restaurar()
+
+    expect(snapshot.state).toBe('deslogado')
+    expect(vault.read()).toBeUndefined()
+  })
+})
+
+describe('AuthService — logout (critério 3)', () => {
+  it('apaga tokens, metadados e audita, voltando para deslogado', async () => {
+    semearSessaoAtiva()
+    const service = criarServico()
+    await service.restaurar()
+
+    const snapshot = await service.logout()
+
+    expect(snapshot.state).toBe('deslogado')
+    expect(snapshot.profile).toBeUndefined()
+    expect(vault.read()).toBeUndefined()
+    expect(sessions.findActive(SESSAO_SUPABASE.user.id)).toBeUndefined()
+    expect(audit.list(SESSAO_SUPABASE.user.id).map((e) => e.type)).toContain('logout')
+  })
+
+  it('limpa o estado local mesmo quando a revogação online falha', async () => {
+    semearSessaoAtiva()
+    const service = criarServico(
+      supabaseDublado({
+        signOut: vi.fn().mockRejectedValue(new Error('fetch failed'))
+      })
+    )
+    await service.restaurar()
+
+    const snapshot = await service.logout()
+
+    // O usuário pediu para sair: ficar preso numa sessão por falta de rede seria o pior
+    // resultado possível numa máquina compartilhada.
+    expect(snapshot.state).toBe('deslogado')
+    expect(vault.read()).toBeUndefined()
+  })
+})
+
+describe('AuthService — logging da categoria auth (critério 8)', () => {
+  it('não grava token nem refresh token em nenhum registro de log', async () => {
+    semearSessaoAtiva()
+    const service = criarServico()
+
+    await service.restaurar()
+    await service.logout()
+
+    // Varre tudo que foi logado — mensagem e contexto — atrás dos segredos.
+    const tudoQueFoiLogado = JSON.stringify([
+      ...logCat.info.mock.calls,
+      ...logCat.warn.mock.calls,
+      ...logCat.error.mock.calls
+    ])
+
+    expect(tudoQueFoiLogado).not.toContain(ACCESS_TOKEN)
+    expect(tudoQueFoiLogado).not.toContain(REFRESH_TOKEN)
+  })
+
+  it('emite info nas transições do fluxo feliz', async () => {
+    semearSessaoAtiva()
+    await criarServico().restaurar()
+
+    expect(logCat.info).toHaveBeenCalled()
+  })
+})
+
+describe('servidor loopback', () => {
+  it('atende em 127.0.0.1 e devolve o code da query string', async () => {
+    const handle = await startLoopbackServer(5000)
+
+    try {
+      expect(handle.redirectUri).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
+
+      const resposta = await fetch(`${handle.redirectUri}/?code=abc-123`)
+      expect(resposta.ok).toBe(true)
+
+      await expect(handle.resultado).resolves.toEqual({ code: 'abc-123', error: undefined })
+    } finally {
+      handle.close()
+    }
+  })
+
+  it('propaga o erro devolvido pelo provedor', async () => {
+    const handle = await startLoopbackServer(5000)
+
+    try {
+      await fetch(`${handle.redirectUri}/?error=access_denied`)
+      await expect(handle.resultado).resolves.toEqual({
+        code: undefined,
+        error: 'access_denied'
+      })
+    } finally {
+      handle.close()
+    }
+  })
+})

--- a/src/main/auth/auth-service.ts
+++ b/src/main/auth/auth-service.ts
@@ -1,0 +1,314 @@
+/**
+ * Autenticação Google local-first (SPEC-Fundacao-03).
+ *
+ * O serviço vive no main e é o **único** ponto do app que enxerga token. O renderer recebe
+ * `AuthSnapshot` (estado + perfil) e nada mais — é o critério 4 expresso em código: não há
+ * método aqui que devolva credencial, então não existe caminho tipado até ela.
+ *
+ * Local-first (ADR-001): o primeiro login exige internet; depois a sessão cacheada vale por
+ * 30 dias sem revalidação online (decisão do PI, questão aberta 2 do ADR-001). Enquanto a
+ * janela estiver aberta, relançar offline entra direto.
+ *
+ * Dependências entram por construtor — Supabase, cofre, auditoria, repositórios e o
+ * "abrir navegador" —, o que mantém o fluxo inteiro testável sem rede e sem Electron.
+ */
+
+import { randomUUID } from 'node:crypto'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  AUTH_MENSAGENS,
+  DESLOGADO,
+  OFFLINE_SESSION_MAX_DAYS,
+  type AuthErro,
+  type AuthSnapshot
+} from '@shared/contracts/auth'
+import type { Session, UserProfile } from '@shared/domain/entities'
+import { log } from '../logging/logger'
+import type { AuditRepository } from '../storage/audit-repository'
+import type { SessionRepository, UserProfileRepository } from '../storage/repositories'
+import { startLoopbackServer } from './loopback-server'
+import type { StoredTokens, TokenVault } from './token-vault'
+
+const MS_POR_DIA = 24 * 60 * 60 * 1000
+
+export interface AuthDependencies {
+  readonly supabase: SupabaseClient
+  readonly vault: TokenVault
+  readonly audit: AuditRepository
+  readonly profiles: UserProfileRepository
+  readonly sessions: SessionRepository
+  /** Abre a URL no navegador do sistema. Injetado para o teste não abrir browser real. */
+  readonly openExternal: (url: string) => Promise<void>
+  /** Avisa o renderer de cada transição. O main empurra; a UI não faz polling. */
+  readonly onChange: (snapshot: AuthSnapshot) => void
+  /** Injetável para o teste controlar o relógio sem esperar 30 dias. */
+  readonly now?: () => Date
+}
+
+export class AuthService {
+  private snapshot: AuthSnapshot = DESLOGADO
+
+  constructor(private readonly deps: AuthDependencies) {}
+
+  private get agora(): Date {
+    return this.deps.now?.() ?? new Date()
+  }
+
+  atual(): AuthSnapshot {
+    return this.snapshot
+  }
+
+  /** Usuário corrente, ou `undefined` quando deslogado. Quem audita precisa disto. */
+  usuarioAtual(): UserProfile | undefined {
+    return this.snapshot.profile
+  }
+
+  /**
+   * Publica o novo estado e avisa o renderer. Toda transição passa por aqui — é o ponto
+   * único que garante que a UI nunca fique dessincronizada do main.
+   */
+  private transicionar(snapshot: AuthSnapshot): AuthSnapshot {
+    this.snapshot = snapshot
+    this.deps.onChange(snapshot)
+    return snapshot
+  }
+
+  /** Estado de erro com mensagem pronta para a tela (critério 6: sem stack na UI). */
+  private falhar(motivo: AuthErro, error?: unknown): AuthSnapshot {
+    // O detalhe técnico vai para o log; a UI recebe só a frase do contrato.
+    log.auth.error('Falha no fluxo de autenticação', { motivo, error })
+
+    return this.transicionar({
+      state: motivo === 'sessao-expirada' ? 'sessao-expirada' : 'erro',
+      mensagem: AUTH_MENSAGENS[motivo]
+    })
+  }
+
+  /**
+   * Retoma a sessão do cofre no boot, sem exigir rede (critério 2).
+   *
+   * A ordem importa: valida a janela offline **antes** de tentar qualquer coisa online.
+   * Um app que precisa da rede para descobrir que pode operar offline não é local-first.
+   */
+  async restaurar(): Promise<AuthSnapshot> {
+    const tokens = this.deps.vault.read()
+    if (!tokens) return this.transicionar(DESLOGADO)
+
+    const sessao = this.deps.sessions.findActive(this.userIdDeToken(tokens))
+    if (!sessao) {
+      // Cofre sem metadados = estado inconsistente; trata como deslogado em vez de
+      // confiar num token cuja validade não dá para situar no tempo.
+      this.deps.vault.clear()
+      return this.transicionar(DESLOGADO)
+    }
+
+    if (this.janelaOfflineVencida(sessao)) {
+      // Passou dos 30 dias: exige reautenticação, mesmo com token no disco.
+      this.deps.vault.clear()
+      this.deps.sessions.deleteForUser(sessao.user_id)
+      return this.falhar('sessao-expirada')
+    }
+
+    const profile = this.deps.profiles.findById(sessao.user_id)
+    if (!profile) {
+      this.deps.vault.clear()
+      return this.transicionar(DESLOGADO)
+    }
+
+    // Reuso de sessão é evento auditável (critério 5) — é a prova de que o app entrou
+    // sem passar pelo provedor de identidade naquele boot.
+    this.deps.audit.append({
+      user_id: profile.id,
+      type: 'login-offline-reuse',
+      payload: { expiresAt: sessao.expires_at }
+    })
+
+    log.auth.info('Sessão restaurada do cofre local', { expiresAt: sessao.expires_at })
+
+    return this.transicionar({
+      state: 'ativo',
+      profile,
+      expiresAt: sessao.expires_at
+    })
+  }
+
+  /**
+   * Login Google completo: abre o navegador, espera o loopback, troca o código por sessão.
+   *
+   * O `code` só vira sessão através do `exchangeCodeForSession` do Supabase (PKCE): o
+   * `code_verifier` fica no cliente e nunca sai daqui, então interceptar o redirect não
+   * basta para forjar a sessão.
+   */
+  async login(): Promise<AuthSnapshot> {
+    this.transicionar({ state: 'autenticando' })
+
+    let handle: Awaited<ReturnType<typeof startLoopbackServer>> | undefined
+
+    try {
+      handle = await startLoopbackServer()
+
+      const { data, error } = await this.deps.supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo: handle.redirectUri,
+          // O app abre a URL no navegador do sistema; o supabase-js não redireciona
+          // sozinho porque aqui não existe `window.location`.
+          skipBrowserRedirect: true
+        }
+      })
+
+      if (error || !data?.url) return this.falhar('falha-no-provedor', error)
+
+      await this.deps.openExternal(data.url)
+      log.auth.info('Fluxo de login aberto no navegador do sistema')
+
+      const retorno = await handle.resultado
+
+      if (retorno.error) return this.falhar('cancelado-pelo-usuario', retorno.error)
+      if (!retorno.code) return this.falhar('falha-no-provedor')
+
+      const troca = await this.deps.supabase.auth.exchangeCodeForSession(retorno.code)
+      if (troca.error || !troca.data?.session) {
+        return this.falhar('falha-no-provedor', troca.error)
+      }
+
+      return this.concluirLogin(troca.data.session)
+    } catch (error) {
+      // Sem rede o `signInWithOAuth` estoura antes de abrir o navegador; a mensagem
+      // precisa dizer isso, e não "falha no provedor", que mandaria o usuário tentar
+      // de novo contra a causa errada.
+      return this.falhar(this.classificar(error), error)
+    } finally {
+      handle?.close()
+    }
+  }
+
+  /**
+   * Persiste sessão, perfil e tokens; audita e ativa.
+   *
+   * Grava perfil e metadados **antes** dos tokens: um cofre com token cujo perfil não
+   * existe é o estado inconsistente que o `restaurar()` teria de limpar no boot seguinte.
+   */
+  private concluirLogin(sessao: {
+    access_token: string
+    refresh_token: string
+    expires_at?: number
+    user: { id: string; email?: string; user_metadata?: Record<string, unknown> }
+  }): AuthSnapshot {
+    const agora = this.agora
+    const nome =
+      typeof sessao.user.user_metadata?.full_name === 'string'
+        ? sessao.user.user_metadata.full_name
+        : (sessao.user.email ?? 'Usuário')
+
+    // Preserva as preferências de quem já entrou antes: `save` só atualiza identidade
+    // (ver `UserProfileRepository.save`), então idioma e tema escolhidos sobrevivem.
+    const existente = this.deps.profiles.findById(sessao.user.id)
+    const profile = this.deps.profiles.save({
+      id: sessao.user.id,
+      name: nome,
+      email: sessao.user.email ?? '',
+      locale: existente?.locale ?? 'pt-BR',
+      theme: existente?.theme ?? 'sistema'
+    })
+
+    const expiresAt = new Date(agora.getTime() + OFFLINE_SESSION_MAX_DAYS * MS_POR_DIA)
+    const metadados: Session = {
+      id: randomUUID(),
+      user_id: profile.id,
+      expires_at: expiresAt.toISOString(),
+      last_online_auth_at: agora.toISOString(),
+      created_at: agora.toISOString()
+    }
+
+    this.deps.sessions.deleteForUser(profile.id)
+    this.deps.sessions.save(metadados)
+
+    this.deps.vault.write({
+      accessToken: sessao.access_token,
+      refreshToken: sessao.refresh_token,
+      expiresAt: sessao.expires_at ?? Math.floor(expiresAt.getTime() / 1000)
+    })
+
+    this.deps.audit.append({
+      user_id: profile.id,
+      type: 'login',
+      payload: { metodo: 'google', expiresAt: metadados.expires_at }
+    })
+
+    // `email` fica fora do ctx: é dado pessoal, e a redaction do ADR-005 mascara
+    // `personal`. O que interessa ao diagnóstico é que houve login e até quando ele vale.
+    log.auth.info('Login concluído', { expiresAt: metadados.expires_at })
+
+    return this.transicionar({
+      state: 'ativo',
+      profile,
+      expiresAt: metadados.expires_at
+    })
+  }
+
+  /**
+   * Logout: revoga no servidor quando dá, e **sempre** limpa o local (critério 3).
+   *
+   * A ordem é deliberada: a limpeza local não pode depender da rede. Se `signOut` falhar
+   * offline e isso abortasse o logout, o usuário ficaria preso numa sessão que pediu para
+   * encerrar — o pior resultado possível numa máquina compartilhada.
+   */
+  async logout(): Promise<AuthSnapshot> {
+    const profile = this.snapshot.profile
+
+    try {
+      await this.deps.supabase.auth.signOut()
+    } catch (error) {
+      log.auth.warn('Falha ao revogar a sessão no servidor; seguindo com a limpeza local', {
+        error
+      })
+    }
+
+    this.deps.vault.clear()
+
+    if (profile) {
+      this.deps.sessions.deleteForUser(profile.id)
+      this.deps.audit.append({ user_id: profile.id, type: 'logout', payload: {} })
+    }
+
+    log.auth.info('Logout concluído; estado local limpo')
+
+    return this.transicionar(DESLOGADO)
+  }
+
+  /** Vencida quando passou a janela de 30 dias desde a última autenticação online. */
+  private janelaOfflineVencida(sessao: Session): boolean {
+    return this.agora.getTime() > new Date(sessao.expires_at).getTime()
+  }
+
+  /**
+   * Descobre de quem é o token guardado sem decodificar o JWT.
+   *
+   * O cofre não guarda `user_id` e decodificar a claim aqui significaria confiar no
+   * conteúdo do token — que é o que o Supabase valida, não o app. A sessão mais recente
+   * do SQLite responde a pergunta: só existe uma por vez (o login apaga as anteriores).
+   */
+  private userIdDeToken(_tokens: StoredTokens): string {
+    const linha = this.deps.sessions.findMostRecent()
+    return linha?.user_id ?? ''
+  }
+
+  /** Traduz a exceção para o enum fechado do contrato (critério 6). */
+  private classificar(error: unknown): AuthErro {
+    const mensagem = error instanceof Error ? error.message.toLowerCase() : ''
+
+    if (
+      mensagem.includes('fetch failed') ||
+      mensagem.includes('enotfound') ||
+      mensagem.includes('econnrefused') ||
+      mensagem.includes('network')
+    ) {
+      return 'sem-conexao'
+    }
+
+    if (mensagem.includes('tempo esgotado')) return 'cancelado-pelo-usuario'
+
+    return 'falha-no-provedor'
+  }
+}

--- a/src/main/auth/loopback-server.ts
+++ b/src/main/auth/loopback-server.ts
@@ -1,0 +1,123 @@
+/**
+ * Servidor loopback temporário que recebe o retorno do OAuth (SPEC-03, pergunta 2 do PI).
+ *
+ * Por que loopback e não webview: o fluxo abre no **navegador do sistema**, onde o usuário
+ * vê a barra de endereço real do Google e o app não enxerga o que ele digita. Um webview
+ * embutido daria ao app acesso ao formulário de senha — exatamente o que se quer evitar.
+ *
+ * O servidor nasce no `login()`, atende **uma** requisição e morre. Não fica escutando:
+ * porta aberta ociosa num app desktop é superfície de ataque sem contrapartida.
+ */
+
+import { createServer, type Server } from 'node:http'
+import { log } from '../logging/logger'
+
+/** Porta 0 = o SO escolhe uma livre. Fixar porta quebraria com duas instâncias. */
+const PORTA_EFEMERA = 0
+
+/** O que o Google/Supabase devolve na query string do redirect. */
+export interface CallbackResult {
+  readonly code?: string
+  readonly error?: string
+}
+
+/** Página mostrada no navegador ao fim do fluxo — o usuário volta para o app sozinho. */
+function paginaDeRetorno(sucesso: boolean): string {
+  const titulo = sucesso ? 'Login concluído' : 'Login não concluído'
+  const corpo = sucesso
+    ? 'Você já pode voltar para o JARVIS OS.'
+    : 'Algo deu errado. Volte para o JARVIS OS e tente novamente.'
+
+  return `<!doctype html>
+<html lang="pt-BR">
+  <head><meta charset="utf-8"><title>${titulo}</title></head>
+  <body style="font-family: system-ui, sans-serif; display: grid; place-items: center; height: 100vh; margin: 0;">
+    <main style="text-align: center;">
+      <h1 style="font-size: 1.25rem;">${titulo}</h1>
+      <p style="color: #555;">${corpo}</p>
+    </main>
+  </body>
+</html>`
+}
+
+export interface LoopbackHandle {
+  /** URL que o Supabase deve usar como `redirectTo`. */
+  readonly redirectUri: string
+  /** Resolve quando o navegador bater de volta; rejeita no timeout ou no cancelamento. */
+  readonly resultado: Promise<CallbackResult>
+  /** Derruba o servidor. Idempotente — seguro chamar no `finally`. */
+  close(): void
+}
+
+/**
+ * Sobe o servidor e devolve a URI de retorno junto com a promessa do resultado.
+ *
+ * `timeoutMs` existe para o fluxo não ficar pendurado quando o usuário abandona a aba do
+ * navegador: sem ele, a promessa nunca resolveria e o estado `autenticando` travaria a UI.
+ */
+export function startLoopbackServer(timeoutMs = 5 * 60 * 1000): Promise<LoopbackHandle> {
+  return new Promise<LoopbackHandle>((resolveHandle, rejectHandle) => {
+    let servidor: Server
+    let encerrado = false
+    let temporizador: NodeJS.Timeout
+
+    const resultado = new Promise<CallbackResult>((resolve, reject) => {
+      servidor = createServer((req, res) => {
+        // `req.url` é sempre relativo; a base só existe para o parser aceitar.
+        const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+        const code = url.searchParams.get('code') ?? undefined
+        const error = url.searchParams.get('error') ?? undefined
+
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.end(paginaDeRetorno(Boolean(code)))
+
+        resolve({ code, error })
+      })
+
+      temporizador = setTimeout(() => {
+        reject(new Error('Tempo esgotado aguardando o retorno do login.'))
+      }, timeoutMs)
+
+      // Falha de bind (porta ocupada, permissão) precisa rejeitar **os dois**: quem
+      // espera o handle e quem espera o resultado. Só o segundo deixaria o `login()`
+      // pendurado para sempre no `await startLoopbackServer()`.
+      servidor.on('error', (error) => {
+        log.auth.error('Falha no servidor de retorno do login', { error })
+        rejectHandle(error)
+        reject(error)
+      })
+
+      // `127.0.0.1` e não `localhost`: evita depender da resolução de nome e impede
+      // que a porta atenda em interface externa.
+      servidor.listen(PORTA_EFEMERA, '127.0.0.1', () => {
+        const address = servidor.address()
+
+        if (typeof address === 'string' || address === null) {
+          const erro = new Error('Não foi possível determinar a porta do servidor de retorno.')
+          rejectHandle(erro)
+          reject(erro)
+          return
+        }
+
+        const redirectUri = `http://127.0.0.1:${address.port}`
+        log.auth.info('Servidor de retorno do login iniciado', { porta: address.port })
+
+        resolveHandle({
+          redirectUri,
+          resultado,
+          close: () => {
+            if (encerrado) return
+            encerrado = true
+            clearTimeout(temporizador)
+            servidor.close()
+            log.auth.info('Servidor de retorno do login encerrado')
+          }
+        })
+      })
+    })
+
+    // Sem isto, um `reject` antes de alguém assinar `resultado` viraria unhandled rejection
+    // e derrubaria o processo pelo handler global do `main/index.ts`.
+    resultado.catch(() => undefined)
+  })
+}

--- a/src/main/auth/supabase-client.ts
+++ b/src/main/auth/supabase-client.ts
@@ -1,0 +1,106 @@
+/**
+ * Cliente Supabase do main (ADR-002).
+ *
+ * Duas adaptações que o ambiente exige, ambas por não haver navegador aqui:
+ *
+ * 1. **Storage adapter sobre o cofre.** O supabase-js persiste sessão em `localStorage`
+ *    por padrão; no main isso não existe, e mesmo que existisse gravaria token em claro.
+ *    O adapter redireciona a persistência para o `safeStorage`/DPAPI (critério 7).
+ * 2. **`detectSessionInUrl: false`.** Não há `window.location` para inspecionar — quem
+ *    captura o código é o servidor loopback, e a troca é explícita no `AuthService`.
+ *
+ * A chave usada é a **publicável**. A `service_role` ignora RLS e nunca entra num app
+ * distribuído ao usuário final — está dito no `.env.example` e vale como regra.
+ */
+
+import { createClient, type SupabaseClient, type SupportedStorage } from '@supabase/supabase-js'
+import type { TokenVault } from './token-vault'
+
+/** Credenciais lidas do ambiente. Ausentes = login indisponível, app segue funcionando. */
+export interface SupabaseConfig {
+  readonly url: string
+  readonly publishableKey: string
+}
+
+/**
+ * Lê as credenciais do ambiente. Devolve `undefined` quando faltam, em vez de lançar:
+ * sem elas o app roda normalmente e só o login fica indisponível (`.env.example`), que é
+ * o comportamento esperado por quem clona o repo sem projeto Supabase.
+ */
+export function readSupabaseConfig(env: NodeJS.ProcessEnv = process.env): SupabaseConfig | undefined {
+  const url = env.SUPABASE_URL?.trim()
+  const publishableKey = env.SUPABASE_PUBLISHABLE_KEY?.trim()
+
+  if (!url || !publishableKey) return undefined
+
+  return { url, publishableKey }
+}
+
+/**
+ * Adapter que faz o supabase-js persistir no cofre cifrado.
+ *
+ * O supabase-js guarda um JSON de sessão inteiro sob uma chave própria; aqui ele é mapeado
+ * para os três campos que o cofre conhece. Só a chave de sessão é atendida — qualquer
+ * outra (o `code_verifier` do PKCE, efêmero) fica em memória, que é onde deve ficar.
+ */
+export function createVaultStorage(vault: TokenVault): SupportedStorage {
+  const efemeros = new Map<string, string>()
+
+  const ehChaveDeSessao = (key: string): boolean => key.endsWith('-auth-token')
+
+  return {
+    getItem: (key) => {
+      if (!ehChaveDeSessao(key)) return efemeros.get(key) ?? null
+
+      const tokens = vault.read()
+      if (!tokens) return null
+
+      return JSON.stringify({
+        access_token: tokens.accessToken,
+        refresh_token: tokens.refreshToken,
+        expires_at: tokens.expiresAt
+      })
+    },
+    setItem: (key, value) => {
+      if (!ehChaveDeSessao(key)) {
+        efemeros.set(key, value)
+        return
+      }
+
+      try {
+        const parsed = JSON.parse(value) as {
+          access_token?: string
+          refresh_token?: string
+          expires_at?: number
+        }
+
+        if (!parsed.access_token || !parsed.refresh_token) return
+
+        vault.write({
+          accessToken: parsed.access_token,
+          refreshToken: parsed.refresh_token,
+          expiresAt: parsed.expires_at ?? 0
+        })
+      } catch {
+        // Valor fora do formato esperado não vira gravação silenciosa de lixo no cofre.
+      }
+    },
+    removeItem: (key) => {
+      if (ehChaveDeSessao(key)) vault.clear()
+      else efemeros.delete(key)
+    }
+  }
+}
+
+export function createSupabaseClient(config: SupabaseConfig, vault: TokenVault): SupabaseClient {
+  return createClient(config.url, config.publishableKey, {
+    auth: {
+      flowType: 'pkce',
+      persistSession: true,
+      autoRefreshToken: true,
+      // Não há URL de navegador para inspecionar; o loopback entrega o código.
+      detectSessionInUrl: false,
+      storage: createVaultStorage(vault)
+    }
+  })
+}

--- a/src/main/auth/supabase-client.ts
+++ b/src/main/auth/supabase-client.ts
@@ -27,7 +27,9 @@ export interface SupabaseConfig {
  * sem elas o app roda normalmente e só o login fica indisponível (`.env.example`), que é
  * o comportamento esperado por quem clona o repo sem projeto Supabase.
  */
-export function readSupabaseConfig(env: NodeJS.ProcessEnv = process.env): SupabaseConfig | undefined {
+export function readSupabaseConfig(
+  env: NodeJS.ProcessEnv = process.env
+): SupabaseConfig | undefined {
   const url = env.SUPABASE_URL?.trim()
   const publishableKey = env.SUPABASE_PUBLISHABLE_KEY?.trim()
 

--- a/src/main/auth/token-vault.spec.ts
+++ b/src/main/auth/token-vault.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Cofre de tokens (SPEC-Fundacao-03, critério 7).
+ *
+ * O critério é verificável de uma forma só: **ler os bytes do arquivo** e confirmar que o
+ * token não está lá. Um teste que apenas chamasse `write` e `read` passaria mesmo se a
+ * implementação gravasse JSON em claro — por isso aqui se inspeciona o disco.
+ *
+ * O `safeStorage` é dublado porque o real exige o Electron rodando e a chave do usuário do
+ * SO. O dublê **cifra de verdade** (XOR + base64): fraco para produção, suficiente para o
+ * teste, porque o que se prova é que a implementação passa o conteúdo pela cifra antes de
+ * escrever — não a força do algoritmo do SO.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const logCat = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+vi.mock('../logging/logger', () => ({
+  log: new Proxy({}, { get: () => logCat }),
+  setCurrentWorkspace: vi.fn()
+}))
+
+/** Cifra simétrica de brinquedo — embaralha o suficiente para o texto não ficar legível. */
+const CHAVE = 0x5a
+let cifraDisponivel = true
+
+function embaralhar(texto: string): Buffer {
+  return Buffer.from(Array.from(Buffer.from(texto, 'utf8'), (b) => b ^ CHAVE))
+}
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => cifraDisponivel,
+    encryptString: (texto: string) => embaralhar(texto),
+    decryptString: (buffer: Buffer) =>
+      Buffer.from(Array.from(buffer, (b) => b ^ CHAVE)).toString('utf8')
+  }
+}))
+
+const { SafeStorageTokenVault } = await import('./token-vault')
+
+const TOKENS = {
+  accessToken: 'access-token-secreto-abc123',
+  refreshToken: 'refresh-token-secreto-xyz789',
+  expiresAt: 1_800_000_000
+}
+
+let dir: string
+let vaultPath: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'jarvis-vault-'))
+  vaultPath = join(dir, 'session.vault')
+  cifraDisponivel = true
+  logCat.warn.mockClear()
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('SafeStorageTokenVault (critério 7)', () => {
+  it('o arquivo gravado não contém o token nem o refresh token em claro', () => {
+    new SafeStorageTokenVault(vaultPath).write(TOKENS)
+
+    // Lê os bytes crus: é a única forma de provar que o segredo não está no disco.
+    const bytes = readFileSync(vaultPath)
+    const comoTexto = bytes.toString('utf8')
+    const comoLatin1 = bytes.toString('latin1')
+
+    for (const conteudo of [comoTexto, comoLatin1]) {
+      expect(conteudo).not.toContain(TOKENS.accessToken)
+      expect(conteudo).not.toContain(TOKENS.refreshToken)
+    }
+  })
+
+  it('devolve os tokens intactos na leitura', () => {
+    const vault = new SafeStorageTokenVault(vaultPath)
+    vault.write(TOKENS)
+
+    expect(vault.read()).toEqual(TOKENS)
+  })
+
+  it('devolve undefined quando ainda não há cofre', () => {
+    expect(new SafeStorageTokenVault(vaultPath).read()).toBeUndefined()
+  })
+
+  it('clear apaga o arquivo e é idempotente', () => {
+    const vault = new SafeStorageTokenVault(vaultPath)
+    vault.write(TOKENS)
+
+    vault.clear()
+    expect(existsSync(vaultPath)).toBe(false)
+
+    // Chamar de novo não pode estourar: o logout roda mesmo sem cofre existente.
+    expect(() => vault.clear()).not.toThrow()
+  })
+
+  it('trata cofre corrompido como ausência de sessão, sem derrubar o app', () => {
+    const vault = new SafeStorageTokenVault(vaultPath)
+    writeFileSync(vaultPath, Buffer.from('conteúdo que não é um cofre válido'))
+
+    // Disco corrompido ou perfil do SO recriado: o usuário entra de novo, o app não cai.
+    expect(vault.read()).toBeUndefined()
+    expect(existsSync(vaultPath)).toBe(false)
+  })
+
+  it('recusa operar quando a cifra do SO não está disponível', () => {
+    cifraDisponivel = false
+
+    // Falhar alto é deliberado: gravar refresh token em claro seria pior que não ter cofre.
+    expect(() => new SafeStorageTokenVault(vaultPath)).toThrow(/safeStorage/)
+  })
+})

--- a/src/main/auth/token-vault.ts
+++ b/src/main/auth/token-vault.ts
@@ -1,0 +1,106 @@
+/**
+ * Cofre dos tokens da sessão — selado no `safeStorage`/DPAPI (SPEC-03, critério 7).
+ *
+ * Mesma forma do `audit-key.ts`, e pelo mesmo motivo: é o único arquivo desta pasta que
+ * toca o Electron. O `AuthService` recebe o cofre por parâmetro e por isso continua
+ * testável sem subir o app.
+ *
+ * O que este arquivo garante: o refresh token **nunca** encosta no disco em claro. O que
+ * ele não garante (limite honesto, igual ao do ADR-004): num host single-user, quem tem o
+ * mesmo usuário do SO destrava o DPAPI. A proteção é contra leitura do arquivo por outro
+ * usuário ou por cópia do disco — não contra o próprio dono da máquina.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { safeStorage } from 'electron'
+import { log } from '../logging/logger'
+
+/**
+ * O segredo guardado. Espelha o que o Supabase devolve na sessão, reduzido ao necessário
+ * para retomar: nada de claim decodificada, nada de perfil — perfil mora no SQLite.
+ */
+export interface StoredTokens {
+  readonly accessToken: string
+  readonly refreshToken: string
+  /** Epoch em segundos, como o Supabase entrega. */
+  readonly expiresAt: number
+}
+
+/**
+ * Contrato do cofre. Existe para o `AuthService` depender de uma interface e não do
+ * `safeStorage` — é o que permite testá-lo com um cofre em memória.
+ */
+export interface TokenVault {
+  read(): StoredTokens | undefined
+  write(tokens: StoredTokens): void
+  clear(): void
+}
+
+function isStoredTokens(value: unknown): value is StoredTokens {
+  if (typeof value !== 'object' || value === null) return false
+  const candidato = value as Record<string, unknown>
+  return (
+    typeof candidato.accessToken === 'string' &&
+    typeof candidato.refreshToken === 'string' &&
+    typeof candidato.expiresAt === 'number'
+  )
+}
+
+/** Cofre em disco, cifrado pelo SO. `vaultPath` fica em `userData`, fora do repo. */
+export class SafeStorageTokenVault implements TokenVault {
+  constructor(private readonly vaultPath: string) {
+    // Falha alto em vez de gravar token em claro — a mesma regra do `audit-key.ts`.
+    // Um refresh token legível no disco é credencial de longa duração exposta; sem a
+    // cifra do SO, é preferível o app não guardar sessão nenhuma.
+    if (!safeStorage.isEncryptionAvailable()) {
+      throw new Error(
+        'safeStorage indisponível: os tokens da sessão não podem ser protegidos neste ' +
+          'sistema. Gravá-los em claro violaria o critério 7 da SPEC-Fundacao-03.'
+      )
+    }
+  }
+
+  read(): StoredTokens | undefined {
+    if (!existsSync(this.vaultPath)) return undefined
+
+    try {
+      const conteudo = safeStorage.decryptString(readFileSync(this.vaultPath))
+      const parsed: unknown = JSON.parse(conteudo)
+
+      if (!isStoredTokens(parsed)) {
+        // Formato inesperado = cofre inútil. Some com ele e trata como deslogado: manter
+        // um arquivo ilegível só faria a próxima leitura falhar de novo.
+        log.auth.warn('Cofre de tokens com formato inesperado; sessão descartada')
+        this.clear()
+        return undefined
+      }
+
+      return parsed
+    } catch (error) {
+      // Cofre ilegível (troca de usuário do SO, perfil recriado, disco corrompido) não é
+      // motivo para derrubar o app: o usuário simplesmente entra de novo.
+      log.auth.warn('Falha ao decifrar o cofre de tokens; exigindo novo login', { error })
+      this.clear()
+      return undefined
+    }
+  }
+
+  write(tokens: StoredTokens): void {
+    try {
+      mkdirSync(dirname(this.vaultPath), { recursive: true })
+      writeFileSync(this.vaultPath, safeStorage.encryptString(JSON.stringify(tokens)))
+      // Sem `ctx`: nem o tamanho do token entra no log. O que se registra é o fato.
+      log.auth.info('Tokens da sessão gravados cifrados no cofre')
+    } catch (error) {
+      log.auth.error('Falha ao gravar o cofre de tokens', { error })
+      throw error
+    }
+  }
+
+  /** Idempotente: chamar sem cofre existente é no-op, o que simplifica o logout. */
+  clear(): void {
+    rmSync(this.vaultPath, { force: true })
+    log.auth.info('Cofre de tokens apagado')
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,9 @@
 import { join } from 'node:path'
-import { app, BrowserWindow, nativeTheme } from 'electron'
+import { app, BrowserWindow, nativeTheme, shell } from 'electron'
+import { IPC_EVENT_CHANNELS } from '@shared/contracts/ipc'
+import { AuthService } from './auth/auth-service'
+import { createSupabaseClient, readSupabaseConfig } from './auth/supabase-client'
+import { SafeStorageTokenVault } from './auth/token-vault'
 import { registerIpcHandlers } from './ipc/handlers'
 import { PreferencesService } from './preferences/preferences-service'
 import { closeLogger, initLogger, log } from './logging/logger'
@@ -44,10 +48,21 @@ if (!app.requestSingleInstanceLock()) {
 
     // Storage depois do logger, antes dos handlers — que já podem consultá-lo.
     const storage = initStorage(app.getPath('userData'))
-    // Usuário local da fundação; a F03 substitui pelo da sessão real.
+    // Usuário local da fundação: continua sendo a identidade de quem ainda não entrou.
+    // Com a F03, ele deixa de ser o único — o usuário da sessão o substitui após o login.
     storage.profiles.save(LOCAL_USER_PROFILE)
 
-    const workspaces = new WorkspaceService(storage.audit, LOCAL_USER_ID)
+    const auth = criarAuthService(app.getPath('userData'), storage, () => janela)
+
+    /**
+     * Identidade corrente: o usuário da sessão quando há login, o local caso contrário.
+     *
+     * É função porque o valor muda em runtime — capturar a string no boot congelaria o
+     * escopo da auditoria no usuário local para sempre.
+     */
+    const userIdAtual = (): string => auth?.usuarioAtual()?.id ?? LOCAL_USER_ID
+
+    const workspaces = new WorkspaceService(storage.audit, userIdAtual)
     // `nativeTheme` é a única fonte confiável do tema do SO; entra por injeção para o
     // serviço seguir testável sem Electron.
     const preferences = new PreferencesService(storage.profiles, LOCAL_USER_ID, () =>
@@ -58,12 +73,17 @@ if (!app.requestSingleInstanceLock()) {
       audit: storage.audit,
       workspaces,
       preferences,
-      userId: LOCAL_USER_ID,
+      userId: userIdAtual,
+      auth,
       minimizeToTray: () => janela?.hide()
     })
 
     janela = createMainWindow()
     createTray(janela)
+
+    // Restaura a sessão do cofre depois da janela existir: a transição é empurrada ao
+    // renderer, e sem janela o `webContents.send` cairia no vazio.
+    void auth?.restaurar()
 
     // macOS: recriar a janela ao clicar no dock sem janelas abertas.
     app.on('activate', () => {
@@ -74,6 +94,47 @@ if (!app.requestSingleInstanceLock()) {
         revelarJanela(janela)
       }
     })
+  })
+}
+
+/**
+ * Monta o `AuthService`, ou devolve `undefined` quando não há credenciais.
+ *
+ * Ausência de credencial **não** é erro fatal: o app roda com o usuário local e só o login
+ * fica indisponível (documentado no `.env.example`). Derrubar o boot por falta de um
+ * projeto Supabase impediria qualquer um de clonar o repo e rodar.
+ */
+function criarAuthService(
+  userDataDir: string,
+  storage: ReturnType<typeof initStorage>,
+  janelaAtual: () => BrowserWindow | undefined
+): AuthService | undefined {
+  const config = readSupabaseConfig()
+
+  if (!config) {
+    log.auth.warn(
+      'Credenciais do Supabase ausentes: login indisponível. ' +
+        'Preencha SUPABASE_URL e SUPABASE_PUBLISHABLE_KEY no .env (ver .env.example).'
+    )
+    return undefined
+  }
+
+  const vault = new SafeStorageTokenVault(join(userDataDir, 'session.vault'))
+
+  return new AuthService({
+    supabase: createSupabaseClient(config, vault),
+    vault,
+    audit: storage.audit,
+    profiles: storage.profiles,
+    sessions: storage.sessions,
+    openExternal: (url) => shell.openExternal(url),
+    onChange: (snapshot) => {
+      // `isDestroyed` evita erro na corrida entre o fim do login e o fechamento da janela.
+      const alvo = janelaAtual()
+      if (alvo && !alvo.isDestroyed()) {
+        alvo.webContents.send(IPC_EVENT_CHANNELS.authChanged, snapshot)
+      }
+    }
   })
 }
 

--- a/src/main/ipc/handlers.spec.ts
+++ b/src/main/ipc/handlers.spec.ts
@@ -66,7 +66,9 @@ const deps = {
   audit,
   workspaces,
   preferences,
-  userId: 'local',
+  // Função desde a F03: a identidade muda em runtime (local antes do login, usuário da
+  // sessão depois), então os handlers a resolvem a cada chamada em vez de capturá-la.
+  userId: () => 'local',
   minimizeToTray
 } as unknown as IpcDependencies
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -6,8 +6,10 @@ import {
   type AuditVerification,
   type WorkspaceSwitchResult
 } from '@shared/contracts/ipc'
+import { AUTH_MENSAGENS, type AuthSnapshot } from '@shared/contracts/auth'
 import { parseLogInput } from '@shared/contracts/logging-input'
 import { isWorkspaceId, type AuditEvent, type AuditEventType } from '@shared/domain/entities'
+import type { AuthService } from '../auth/auth-service'
 import { log, writeLog } from '../logging/logger'
 import type { PreferencesService } from '../preferences/preferences-service'
 import type { AuditRepository } from '../storage/audit-repository'
@@ -31,7 +33,16 @@ export interface IpcDependencies {
   readonly audit: AuditRepository
   readonly workspaces: WorkspaceService
   readonly preferences: PreferencesService
-  readonly userId: string
+  /**
+   * Dono da auditoria consultada pelo canal `audit:list`.
+   *
+   * É função e não string desde a F03: o usuário deixa de ser fixo — antes do login é o
+   * usuário local, depois é o da sessão. Capturar o valor no registro dos handlers
+   * congelaria o id do boot e faria a UI listar a auditoria de quem não está logado.
+   */
+  readonly userId: () => string
+  /** Ausente quando as credenciais não estão configuradas — o app roda sem login. */
+  readonly auth?: AuthService
   /** Minimizar para o tray. Injetado porque a janela nasce depois dos handlers. */
   readonly minimizeToTray: () => void
 }
@@ -64,7 +75,7 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
   // Auditoria: leitura apenas. O renderer não abre o SQLite (SPEC-04, critério 6), e
   // gravar evento é ato do main disparado por um fluxo real — nunca a pedido da UI.
   ipcMain.handle(IPC_CHANNELS.auditList, (_event, type?: unknown): readonly AuditEvent[] => {
-    const eventos = deps.audit.list(deps.userId)
+    const eventos = deps.audit.list(deps.userId())
     // Filtro de tipo aplicado aqui, e não numa query montada com string vinda do
     // renderer: o canal aceita um valor externo e ele não vira SQL em hipótese alguma.
     const filtrados =
@@ -82,7 +93,7 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
   })
 
   ipcMain.handle(IPC_CHANNELS.auditVerify, (): AuditVerification => {
-    const resultado = deps.audit.verify(deps.userId) as AuditVerification
+    const resultado = deps.audit.verify(deps.userId()) as AuditVerification
 
     if (!resultado.ok) {
       log.ipc.warn('Verificação da cadeia de auditoria acusou quebra', {
@@ -143,6 +154,55 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
       })
       throw error
     }
+  })
+
+  /**
+   * Canais de auth (SPEC-03). Os três devolvem `AuthSnapshot` e nada além — o token não
+   * atravessa a ponte (critério 4). Sem `auth` configurado, respondem o estado de
+   * credenciais ausentes em vez de estourar: o app roda sem login (`.env.example`).
+   */
+  const semCredenciais: AuthSnapshot = {
+    state: 'erro',
+    mensagem: AUTH_MENSAGENS['credenciais-ausentes']
+  }
+
+  ipcMain.handle(IPC_CHANNELS.authGet, (): AuthSnapshot => {
+    return deps.auth?.atual() ?? semCredenciais
+  })
+
+  ipcMain.handle(IPC_CHANNELS.authLogin, async (): Promise<AuthSnapshot> => {
+    log.auth.info('Login solicitado pela interface', {
+      canal: IPC_CHANNELS.authLogin,
+      direction: 'in'
+    })
+
+    if (!deps.auth) {
+      log.auth.warn('Login indisponível: credenciais do Supabase não configuradas')
+      return semCredenciais
+    }
+
+    // O `AuthService` já converte falha em snapshot de erro (critério 6); o catch aqui
+    // cobre só o imprevisto, para o canal nunca rejeitar e deixar a UI pendurada.
+    try {
+      return await deps.auth.login()
+    } catch (error) {
+      log.auth.error('Falha inesperada no canal de login', {
+        canal: IPC_CHANNELS.authLogin,
+        error
+      })
+      return { state: 'erro', mensagem: AUTH_MENSAGENS['falha-no-provedor'] }
+    }
+  })
+
+  ipcMain.handle(IPC_CHANNELS.authLogout, async (): Promise<AuthSnapshot> => {
+    log.auth.info('Logout solicitado pela interface', {
+      canal: IPC_CHANNELS.authLogout,
+      direction: 'in'
+    })
+
+    if (!deps.auth) return semCredenciais
+
+    return await deps.auth.logout()
   })
 
   // Só de ida: o renderer manda o registro, o main grava. Sem resposta de propósito —

--- a/src/main/preload/index.ts
+++ b/src/main/preload/index.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 import {
   BRIDGE_KEY,
   IPC_CHANNELS,
+  IPC_EVENT_CHANNELS,
   IPC_SEND_CHANNELS,
   type AppInfo,
   type AuditVerification,
@@ -9,6 +10,7 @@ import {
   type PreferencesSnapshot,
   type WorkspaceSwitchResult
 } from '@shared/contracts/ipc'
+import type { AuthSnapshot } from '@shared/contracts/auth'
 import type { LogInput } from '@shared/contracts/logging'
 import type {
   AuditEvent,
@@ -42,6 +44,20 @@ const bridge: JarvisBridge = {
     ipcRenderer.invoke(IPC_CHANNELS.preferencesGet),
   savePreferences: (preferences: UserPreferences): Promise<PreferencesSnapshot> =>
     ipcRenderer.invoke(IPC_CHANNELS.preferencesSave, preferences),
+
+  getAuth: (): Promise<AuthSnapshot> => ipcRenderer.invoke(IPC_CHANNELS.authGet),
+  login: (): Promise<AuthSnapshot> => ipcRenderer.invoke(IPC_CHANNELS.authLogin),
+  logout: (): Promise<AuthSnapshot> => ipcRenderer.invoke(IPC_CHANNELS.authLogout),
+
+  onAuthChanged: (listener: (snapshot: AuthSnapshot) => void): (() => void) => {
+    // O `IpcRendererEvent` fica de fora da chamada: ele carrega `sender`, um objeto do
+    // Electron que não pode vazar para o renderer. O listener recebe só o snapshot.
+    const wrapped = (_event: unknown, snapshot: AuthSnapshot): void => listener(snapshot)
+
+    ipcRenderer.on(IPC_EVENT_CHANNELS.authChanged, wrapped)
+
+    return () => ipcRenderer.removeListener(IPC_EVENT_CHANNELS.authChanged, wrapped)
+  },
 
   minimizeToTray: (): void => ipcRenderer.send(IPC_SEND_CHANNELS.windowMinimizeToTray)
 }

--- a/src/main/preload/preload.spec.ts
+++ b/src/main/preload/preload.spec.ts
@@ -128,17 +128,15 @@ describe('ponte do preload', () => {
 
     // A superfície é fechada por nome: um `getToken`/`getSession`/`refreshToken` aqui
     // seria o caminho tipado até a credencial que a SPEC-03 proíbe existir.
-    expect(
-      Object.keys(bridge).some((k) => /token|secret|credential|session/i.test(k))
-    ).toBe(false)
+    expect(Object.keys(bridge).some((k) => /token|secret|credential|session/i.test(k))).toBe(false)
   })
 
   it('onAuthChanged devolve um cancelador e não vaza o evento do Electron', async () => {
     const bridge = await carregarPonte()
     const recebidos: unknown[][] = []
 
-    const cancelar = (bridge.onAuthChanged as (l: (s: unknown) => void) => () => void)(
-      (...args) => recebidos.push(args)
+    const cancelar = (bridge.onAuthChanged as (l: (s: unknown) => void) => () => void)((...args) =>
+      recebidos.push(args)
     )
 
     // O preload registrou no canal de push e devolveu como desassinar — sem isso, o

--- a/src/main/preload/preload.spec.ts
+++ b/src/main/preload/preload.spec.ts
@@ -1,9 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { BRIDGE_KEY, IPC_CHANNELS, IPC_SEND_CHANNELS } from '@shared/contracts/ipc'
+import {
+  BRIDGE_KEY,
+  IPC_CHANNELS,
+  IPC_EVENT_CHANNELS,
+  IPC_SEND_CHANNELS
+} from '@shared/contracts/ipc'
 
 const exposeInMainWorld = vi.fn()
 const invoke = vi.fn().mockResolvedValue({})
 const send = vi.fn()
+const on = vi.fn()
+const removeListener = vi.fn()
 
 vi.mock('electron', () => ({
   contextBridge: {
@@ -11,7 +18,9 @@ vi.mock('electron', () => ({
   },
   ipcRenderer: {
     invoke: (...args: unknown[]) => invoke(...args),
-    send: (...args: unknown[]) => send(...args)
+    send: (...args: unknown[]) => send(...args),
+    on: (...args: unknown[]) => on(...args),
+    removeListener: (...args: unknown[]) => removeListener(...args)
   }
 }))
 
@@ -27,6 +36,8 @@ describe('ponte do preload', () => {
   beforeEach(() => {
     exposeInMainWorld.mockClear()
     invoke.mockClear()
+    on.mockClear()
+    removeListener.mockClear()
     // O preload só expõe a ponte quando o contexto está isolado.
     Object.defineProperty(process, 'contextIsolated', { value: true, configurable: true })
   })
@@ -43,10 +54,14 @@ describe('ponte do preload', () => {
     // deixaria o renderer alcançar qualquer handler do main.
     expect(Object.keys(bridge).sort()).toEqual([
       'getAppInfo',
+      'getAuth',
       'getPreferences',
       'getWorkspace',
       'listAuditEvents',
+      'login',
+      'logout',
       'minimizeToTray',
+      'onAuthChanged',
       'savePreferences',
       'sendLog',
       'switchWorkspace',
@@ -93,6 +108,56 @@ describe('ponte do preload', () => {
     expect(send).toHaveBeenCalledWith(IPC_SEND_CHANNELS.log, registro)
     expect(invoke).not.toHaveBeenCalled()
     expect(retorno).toBeUndefined()
+  })
+
+  it('roteia os canais de auth pelos nomes do contrato', async () => {
+    const bridge = await carregarPonte()
+
+    await (bridge.getAuth as () => Promise<unknown>)()
+    expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.authGet)
+
+    await (bridge.login as () => Promise<unknown>)()
+    expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.authLogin)
+
+    await (bridge.logout as () => Promise<unknown>)()
+    expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.authLogout)
+  })
+
+  it('não expõe nada que entregue token ao renderer (critério 4)', async () => {
+    const bridge = await carregarPonte()
+
+    // A superfície é fechada por nome: um `getToken`/`getSession`/`refreshToken` aqui
+    // seria o caminho tipado até a credencial que a SPEC-03 proíbe existir.
+    expect(
+      Object.keys(bridge).some((k) => /token|secret|credential|session/i.test(k))
+    ).toBe(false)
+  })
+
+  it('onAuthChanged devolve um cancelador e não vaza o evento do Electron', async () => {
+    const bridge = await carregarPonte()
+    const recebidos: unknown[][] = []
+
+    const cancelar = (bridge.onAuthChanged as (l: (s: unknown) => void) => () => void)(
+      (...args) => recebidos.push(args)
+    )
+
+    // O preload registrou no canal de push e devolveu como desassinar — sem isso, o
+    // listener sobreviveria ao componente e vazaria a cada remontagem.
+    expect(on).toHaveBeenCalledWith(IPC_EVENT_CHANNELS.authChanged, expect.any(Function))
+    expect(typeof cancelar).toBe('function')
+
+    // Simula o main empurrando: o listener recebe só o snapshot, nunca o
+    // `IpcRendererEvent` — que carrega `sender` e daria ao renderer um objeto do Electron.
+    const registrado = on.mock.calls.at(-1)?.[1] as (e: unknown, s: unknown) => void
+    registrado({ sender: 'objeto-do-electron' }, { state: 'ativo' })
+
+    expect(recebidos).toEqual([[{ state: 'ativo' }]])
+
+    cancelar()
+    expect(removeListener).toHaveBeenCalledWith(
+      IPC_EVENT_CHANNELS.authChanged,
+      expect.any(Function)
+    )
   })
 
   it('recusa expor a ponte quando contextIsolation está desligado', async () => {

--- a/src/main/storage/repositories.ts
+++ b/src/main/storage/repositories.ts
@@ -151,6 +151,22 @@ export class SessionRepository {
       .get(userId) as Session | undefined
   }
 
+  /**
+   * A sessão mais recente do banco, sem escopo de usuário.
+   *
+   * Exceção deliberada à regra "toda consulta é escopada", e a única aqui: no boot o app
+   * precisa descobrir **de quem** é a sessão guardada, e perguntar isso já sabendo o
+   * `user_id` seria circular. O isolamento não é violado porque o login apaga as sessões
+   * anteriores (`deleteForUser` em `concluirLogin`) — existe no máximo uma linha por vez.
+   * Alternativa descartada: decodificar o JWT do cofre, que faria o app confiar no
+   * conteúdo de um token que quem valida é o Supabase.
+   */
+  findMostRecent(): Session | undefined {
+    return this.db.prepare('SELECT * FROM session ORDER BY created_at DESC LIMIT 1').get() as
+      | Session
+      | undefined
+  }
+
   /** Logout apaga os metadados da sessão. Sessão não é auditoria — pode ser removida. */
   deleteForUser(userId: string): number {
     try {

--- a/src/main/storage/repositories.ts
+++ b/src/main/storage/repositories.ts
@@ -163,8 +163,7 @@ export class SessionRepository {
    */
   findMostRecent(): Session | undefined {
     return this.db.prepare('SELECT * FROM session ORDER BY created_at DESC LIMIT 1').get() as
-      | Session
-      | undefined
+      Session | undefined
   }
 
   /** Logout apaga os metadados da sessão. Sessão não é auditoria — pode ser removida. */

--- a/src/main/workspace/workspace-service.int-spec.ts
+++ b/src/main/workspace/workspace-service.int-spec.ts
@@ -34,7 +34,7 @@ beforeEach(() => {
   audit = new AuditRepository(db, 'chave-de-teste')
   logCat.info.mockClear()
   setCurrentWorkspace.mockClear()
-  service = new WorkspaceService(audit, 'u-1')
+  service = new WorkspaceService(audit, () => 'u-1')
 })
 
 afterEach(() => {

--- a/src/main/workspace/workspace-service.ts
+++ b/src/main/workspace/workspace-service.ts
@@ -23,10 +23,13 @@ export class WorkspaceService {
   constructor(
     private readonly audit: AuditRepository,
     /**
-     * Dono da auditoria. Enquanto a F03 (auth) não existe, o app roda com um usuário
-     * local fixo; quando o login entrar, quem chama passa o `user_id` real da sessão.
+     * Dono da auditoria, resolvido **a cada troca**.
+     *
+     * Virou função na F03: o usuário deixou de ser fixo — é o local antes do login e o da
+     * sessão depois. Guardar a string recebida no construtor congelaria o valor do boot,
+     * e toda troca de espaço feita após o login seria auditada no usuário errado.
      */
-    private readonly userId: string
+    private readonly userId: () => string
   ) {
     setCurrentWorkspace(this.ativo)
   }
@@ -46,7 +49,7 @@ export class WorkspaceService {
     const origem = this.ativo
 
     const evento = this.audit.append({
-      user_id: this.userId,
+      user_id: this.userId(),
       workspace_id: destino,
       type: 'workspace-switch',
       payload: { de: origem, para: destino }

--- a/src/renderer/src/app/App.tsx
+++ b/src/renderer/src/app/App.tsx
@@ -1,10 +1,31 @@
+import { useTranslation } from 'react-i18next'
+import { TelaLogin } from '../auth/TelaLogin'
+import { useAuth } from '../auth/useAuth'
 import { AppShell } from './AppShell'
 
 /**
- * Raiz do renderer. A tela placeholder da Fatia 01 cumpriu seu papel (provar que o
- * renderer monta e que a ponte responde) e deu lugar ao AppShell da Fatia 02 — que herda
- * essa prova: sem a ponte, ele não carrega o espaço ativo.
+ * Raiz do renderer e **porta de entrada** da aplicação (SPEC-Fundacao-03).
+ *
+ * O gate mora aqui, e não dentro do AppShell, para que o shell continue tratando de uma
+ * coisa só (espaços e navegação). Quem não está `ativo` não monta o shell — não é questão
+ * de esconder a UI, e sim de não instanciar o que pressupõe um usuário.
  */
 export function App(): React.JSX.Element {
-  return <AppShell />
+  const { t } = useTranslation()
+  const { auth, carregando, entrar, sair } = useAuth()
+
+  // Enquanto o main não respondeu, nada de piscar a tela de login para quem já tem sessão.
+  if (carregando) {
+    return (
+      <main className="flex h-full items-center justify-center opacity-70">
+        <p>{t('carregando')}</p>
+      </main>
+    )
+  }
+
+  if (auth.state !== 'ativo') {
+    return <TelaLogin auth={auth} onEntrar={() => void entrar()} />
+  }
+
+  return <AppShell perfil={auth.profile} onSair={() => void sair()} />
 }

--- a/src/renderer/src/app/AppShell.test.tsx
+++ b/src/renderer/src/app/AppShell.test.tsx
@@ -10,6 +10,22 @@ const switchWorkspace = vi.fn()
 const getWorkspace = vi.fn()
 const getPreferences = vi.fn()
 const savePreferences = vi.fn()
+const getAuth = vi.fn()
+const login = vi.fn()
+const logout = vi.fn()
+
+/**
+ * Perfil da sessão usada nestes testes. O `App` só monta o AppShell quando a auth está
+ * `ativo` (SPEC-03), então a suíte do shell precisa partir de um usuário logado — o que
+ * ela investiga é espaço e preferências, não o gate de entrada.
+ */
+const PERFIL_LOGADO = {
+  id: 'u-1',
+  name: 'Rodrigo Reis',
+  email: 'rodrigo@example.com',
+  locale: 'pt-BR' as const,
+  theme: 'sistema' as const
+}
 
 function mockarPonte(): void {
   Object.defineProperty(window, 'jarvis', {
@@ -22,7 +38,13 @@ function mockarPonte(): void {
       getPreferences,
       savePreferences,
       listAuditEvents: vi.fn(),
-      verifyAuditChain: vi.fn()
+      verifyAuditChain: vi.fn(),
+      getAuth,
+      login,
+      logout,
+      // Devolve a função de cancelamento, como a ponte real: sem isso o `useEffect`
+      // tentaria chamar `undefined` na desmontagem e o cleanup estouraria.
+      onAuthChanged: vi.fn(() => () => undefined)
     },
     configurable: true,
     writable: true
@@ -41,6 +63,7 @@ beforeEach(() => {
   sendLog.mockClear()
   minimizeToTray.mockClear()
   savePreferences.mockClear()
+  getAuth.mockResolvedValue({ state: 'ativo', profile: PERFIL_LOGADO })
   // O main é a fonte do espaço ativo; o mock reflete a troca, como ele faria.
   getWorkspace.mockResolvedValue('jarvis' as WorkspaceId)
   switchWorkspace.mockImplementation((w: WorkspaceId) =>

--- a/src/renderer/src/app/AppShell.tsx
+++ b/src/renderer/src/app/AppShell.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { WorkspaceId } from '@shared/domain/entities'
+import type { UserProfile, WorkspaceId } from '@shared/domain/entities'
 import { log } from '../lib/log'
 import { usePreferences } from '../preferences/usePreferences'
 import {
@@ -26,7 +26,13 @@ const ACENTO: Readonly<Record<WorkspaceId, { texto: string; borda: string }>> = 
   jarvis: { texto: 'text-sky-600 dark:text-sky-300', borda: 'border-sky-500/70 bg-sky-500/10' }
 }
 
-export function AppShell(): React.JSX.Element {
+interface AppShellProps {
+  /** Usuário da sessão. Opcional só para o app seguir montável sem login configurado. */
+  readonly perfil?: UserProfile
+  readonly onSair?: () => void
+}
+
+export function AppShell({ perfil, onSair }: AppShellProps = {}): React.JSX.Element {
   const { t } = useTranslation()
   const { preferencias, erro: erroPreferencias, salvar } = usePreferences()
 
@@ -137,13 +143,34 @@ export function AppShell(): React.JSX.Element {
             <h1 className={`text-lg font-semibold ${acento.texto}`}>{nomeEspaco}</h1>
             <p className="text-xs opacity-60">{t(`navegacao.${rotaAtiva}`)}</p>
           </div>
-          <button
-            type="button"
-            onClick={() => window.jarvis.minimizeToTray()}
-            className="rounded-md border border-current/20 px-3 py-1.5 text-xs opacity-70 transition hover:bg-current/5"
-          >
-            {t('janela.minimizar')}
-          </button>
+          <div className="flex items-center gap-3">
+            {/* Nome e e-mail visíveis fecham o critério 1 da SPEC-03: a prova de que o
+                login completou é o app mostrar de quem é a sessão. */}
+            {perfil && (
+              <div aria-label={t('auth.conta')} className="text-right">
+                <p className="text-xs font-medium">{perfil.name}</p>
+                <p className="text-xs opacity-60">{perfil.email}</p>
+              </div>
+            )}
+
+            {onSair && (
+              <button
+                type="button"
+                onClick={onSair}
+                className="rounded-md border border-current/20 px-3 py-1.5 text-xs opacity-70 transition hover:bg-current/5"
+              >
+                {t('auth.sair')}
+              </button>
+            )}
+
+            <button
+              type="button"
+              onClick={() => window.jarvis.minimizeToTray()}
+              className="rounded-md border border-current/20 px-3 py-1.5 text-xs opacity-70 transition hover:bg-current/5"
+            >
+              {t('janela.minimizar')}
+            </button>
+          </div>
         </header>
 
         <main className="min-h-0 flex-1 overflow-auto p-6">

--- a/src/renderer/src/auth/TelaLogin.test.tsx
+++ b/src/renderer/src/auth/TelaLogin.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Gate de autenticação na UI (SPEC-Fundacao-03, critérios 1, 3 e 6).
+ *
+ * Renderiza o `App`, e não a `TelaLogin` isolada, porque o que a spec exige é o
+ * comportamento do gate: quem não está `ativo` não alcança o shell. Testar o componente
+ * solto provaria que ele pinta, não que ele protege.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AuthSnapshot } from '@shared/contracts/auth'
+import { App } from '../app/App'
+
+const getAuth = vi.fn()
+const login = vi.fn()
+const logout = vi.fn()
+/** Tipado explicitamente: sem o parâmetro, o vi.fn infere tupla vazia e o teste que
+ *  recupera o listener não compila. */
+const onAuthChanged = vi.fn((_listener: (snapshot: AuthSnapshot) => void) => () => undefined)
+
+const PERFIL = {
+  id: 'u-1',
+  name: 'Rodrigo Reis',
+  email: 'rodrigo@example.com',
+  locale: 'pt-BR' as const,
+  theme: 'sistema' as const
+}
+
+function mockarPonte(): void {
+  Object.defineProperty(window, 'jarvis', {
+    value: {
+      getAppInfo: vi.fn(),
+      sendLog: vi.fn(),
+      minimizeToTray: vi.fn(),
+      switchWorkspace: vi.fn().mockResolvedValue({ workspace: 'jarvis', auditSeq: 1 }),
+      getWorkspace: vi.fn().mockResolvedValue('jarvis'),
+      getPreferences: vi
+        .fn()
+        .mockResolvedValue({ locale: 'pt-BR', theme: 'sistema', resolvedTheme: 'escuro' }),
+      savePreferences: vi.fn(),
+      listAuditEvents: vi.fn(),
+      verifyAuditChain: vi.fn(),
+      getAuth,
+      login,
+      logout,
+      onAuthChanged
+    },
+    configurable: true,
+    writable: true
+  })
+}
+
+/** Renderiza o app com o estado de auth informado e espera a tela assentar. */
+async function renderizarCom(snapshot: AuthSnapshot): Promise<void> {
+  getAuth.mockResolvedValue(snapshot)
+  render(<App />)
+  await waitFor(() => expect(getAuth).toHaveBeenCalled())
+}
+
+beforeEach(() => {
+  getAuth.mockReset()
+  login.mockReset()
+  logout.mockReset()
+  onAuthChanged.mockClear()
+  mockarPonte()
+})
+
+describe('gate de autenticação', () => {
+  it('mostra a tela de login e não monta o shell quando deslogado', async () => {
+    await renderizarCom({ state: 'deslogado' })
+
+    expect(await screen.findByRole('button', { name: /entrar com o google/i })).toBeVisible()
+    // O shell não pode existir: quem não entrou não alcança espaços nem navegação.
+    expect(screen.queryByRole('radiogroup')).not.toBeInTheDocument()
+  })
+
+  it('monta o shell e mostra nome e e-mail quando ativo (critério 1)', async () => {
+    await renderizarCom({ state: 'ativo', profile: PERFIL })
+
+    expect(await screen.findByText('Rodrigo Reis')).toBeVisible()
+    expect(screen.getByText('rodrigo@example.com')).toBeVisible()
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument()
+  })
+
+  it('dispara o login pela ponte ao clicar em entrar', async () => {
+    login.mockResolvedValue({ state: 'ativo', profile: PERFIL })
+    await renderizarCom({ state: 'deslogado' })
+
+    await userEvent.click(await screen.findByRole('button', { name: /entrar com o google/i }))
+
+    expect(login).toHaveBeenCalledTimes(1)
+  })
+
+  it('desabilita o botão enquanto autentica e explica que o navegador abriu', async () => {
+    await renderizarCom({ state: 'autenticando' })
+
+    const botao = await screen.findByRole('button', { name: /aguardando o navegador/i })
+    expect(botao).toBeDisabled()
+    expect(screen.getByText(/volte aqui quando terminar/i)).toBeVisible()
+  })
+
+  it('exibe a mensagem do main no erro, sem stack trace (critério 6)', async () => {
+    const mensagem = 'Sem conexão com a internet. Verifique a rede e tente entrar de novo.'
+    await renderizarCom({ state: 'erro', mensagem })
+
+    const alerta = await screen.findByRole('alert')
+    expect(alerta).toHaveTextContent(mensagem)
+    // Nada de rastro técnico na tela: nem stack, nem nome de arquivo, nem "Error:".
+    expect(alerta.textContent).not.toMatch(/\bat\s|\.ts:\d+|Error:/)
+  })
+
+  it('sessão expirada avisa e oferece tentar novamente', async () => {
+    await renderizarCom({
+      state: 'sessao-expirada',
+      mensagem: 'Sua sessão expirou. Entre novamente para continuar.'
+    })
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/sessão expirou/i)
+    expect(screen.getByRole('button', { name: /tentar novamente/i })).toBeVisible()
+  })
+
+  it('logout volta para a tela de login (critério 3)', async () => {
+    logout.mockResolvedValue({ state: 'deslogado' })
+    await renderizarCom({ state: 'ativo', profile: PERFIL })
+
+    await userEvent.click(await screen.findByRole('button', { name: /^sair$/i }))
+
+    expect(logout).toHaveBeenCalledTimes(1)
+    // A UI reflete o que o main devolveu: o shell some e o perfil deixa de ser exibido.
+    await waitFor(() => expect(screen.queryByText('rodrigo@example.com')).not.toBeInTheDocument())
+    expect(await screen.findByRole('button', { name: /entrar com o google/i })).toBeVisible()
+  })
+
+  it('reflete a transição empurrada pelo main sem novo pedido da UI', async () => {
+    await renderizarCom({ state: 'autenticando' })
+
+    // O login termina no navegador, minutos depois: quem avisa é o push do main.
+    const listener = onAuthChanged.mock.calls[0]?.[0]
+    expect(listener).toBeDefined()
+    listener?.({ state: 'ativo', profile: PERFIL })
+
+    expect(await screen.findByText('rodrigo@example.com')).toBeVisible()
+  })
+})

--- a/src/renderer/src/auth/TelaLogin.tsx
+++ b/src/renderer/src/auth/TelaLogin.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from 'react-i18next'
+import type { AuthSnapshot } from '@shared/contracts/auth'
+
+/**
+ * Tela de entrada (SPEC-Fundacao-03, critérios 1 e 6).
+ *
+ * Apresenta os quatro estados que antecedem `ativo`. A mensagem de falha vem pronta do
+ * main e é exibida **como veio**: o critério 6 proíbe stack trace na UI, e a forma de
+ * garantir isso é o renderer não ter acesso ao erro cru para começo de conversa.
+ *
+ * Estética alinhada ao AppShell — sem design system formal, que é o MVP-003.
+ */
+
+interface TelaLoginProps {
+  readonly auth: AuthSnapshot
+  readonly onEntrar: () => void
+}
+
+export function TelaLogin({ auth, onEntrar }: TelaLoginProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const autenticando = auth.state === 'autenticando'
+  const expirada = auth.state === 'sessao-expirada'
+  const falhou = auth.state === 'erro'
+
+  return (
+    <main className="flex h-full items-center justify-center p-6">
+      <section
+        aria-labelledby="login-titulo"
+        className="w-full max-w-sm rounded-2xl border border-current/10 bg-current/5 p-8 text-center"
+      >
+        <h1 id="login-titulo" className="text-xl font-semibold text-sky-600 dark:text-sky-300">
+          {t('auth.titulo')}
+        </h1>
+
+        <p className="mt-2 text-sm opacity-70">
+          {autenticando ? t('auth.entrandoDescricao') : t('auth.subtitulo')}
+        </p>
+
+        {/* `role="alert"` nos dois casos: a transição para erro ou expiração acontece
+            depois de o usuário sair da tela, e precisa ser anunciada quando ele volta. */}
+        {(falhou || expirada) && auth.mensagem && (
+          <p
+            role="alert"
+            className="mt-4 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-600 dark:text-rose-300"
+          >
+            {auth.mensagem}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={onEntrar}
+          disabled={autenticando}
+          className="mt-6 w-full rounded-lg border border-sky-500/60 bg-sky-500/10 px-4 py-2.5 text-sm font-medium text-sky-700 transition hover:bg-sky-500/20 disabled:cursor-not-allowed disabled:opacity-60 dark:text-sky-200"
+        >
+          {autenticando
+            ? t('auth.entrando')
+            : falhou || expirada
+              ? t('auth.tentarNovamente')
+              : t('auth.entrar')}
+        </button>
+      </section>
+    </main>
+  )
+}

--- a/src/renderer/src/auth/useAuth.ts
+++ b/src/renderer/src/auth/useAuth.ts
@@ -1,0 +1,73 @@
+/**
+ * Estado de autenticação no renderer (SPEC-Fundacao-03).
+ *
+ * O hook **espelha** o main; não decide nada. Quem sabe se há sessão, se ela venceu e
+ * quem é o usuário é o `AuthService` — aqui só se reflete o `AuthSnapshot` que chega.
+ * É o que mantém o critério 4: não existe token neste lado da ponte para vazar.
+ *
+ * A assinatura do push (`onAuthChanged`) é essencial e não decorativa: o login acontece
+ * fora do app, no navegador, e pode terminar minutos depois. Sem push, a UI ficaria presa
+ * em `autenticando` até alguém consultar de novo.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { DESLOGADO, type AuthSnapshot } from '@shared/contracts/auth'
+import { log } from '../lib/log'
+
+export interface UseAuth {
+  readonly auth: AuthSnapshot
+  readonly carregando: boolean
+  readonly entrar: () => Promise<void>
+  readonly sair: () => Promise<void>
+}
+
+export function useAuth(): UseAuth {
+  const [auth, setAuth] = useState<AuthSnapshot>(DESLOGADO)
+  const [carregando, setCarregando] = useState(true)
+
+  useEffect(() => {
+    // Assina **antes** de consultar: entre a consulta e a assinatura o main pode concluir
+    // a restauração da sessão, e essa transição não pode se perder.
+    const cancelar = window.jarvis.onAuthChanged((snapshot) => {
+      setAuth(snapshot)
+      setCarregando(false)
+    })
+
+    window.jarvis
+      .getAuth()
+      .then((snapshot) => {
+        setAuth(snapshot)
+        setCarregando(false)
+      })
+      .catch((error: unknown) => {
+        log.ui.error('Falha ao consultar o estado de autenticação', { error })
+        setCarregando(false)
+      })
+
+    return cancelar
+  }, [])
+
+  const entrar = useCallback(async (): Promise<void> => {
+    // O estado `autenticando` chega pelo push do main; não se antecipa aqui para a UI não
+    // divergir do que o serviço de fato fez.
+    try {
+      const snapshot = await window.jarvis.login()
+      setAuth(snapshot)
+      log.ui.info('Fluxo de login concluído pela UI', { estado: snapshot.state })
+    } catch (error) {
+      log.ui.error('Falha ao iniciar o login', { error })
+    }
+  }, [])
+
+  const sair = useCallback(async (): Promise<void> => {
+    try {
+      const snapshot = await window.jarvis.logout()
+      setAuth(snapshot)
+      log.ui.info('Logout concluído pela UI')
+    } catch (error) {
+      log.ui.error('Falha ao encerrar a sessão', { error })
+    }
+  }, [])
+
+  return { auth, carregando, entrar, sair }
+}

--- a/src/renderer/src/i18n/recursos.ts
+++ b/src/renderer/src/i18n/recursos.ts
@@ -47,6 +47,21 @@ export const RECURSOS = {
         temaSistema: 'Sistema',
         salvo: 'Preferências salvas.'
       },
+      auth: {
+        titulo: 'JARVIS OS',
+        subtitulo: 'Entre com sua conta Google para começar.',
+        entrar: 'Entrar com o Google',
+        entrando: 'Aguardando o navegador…',
+        entrandoDescricao:
+          'Concluímos o login na aba que abrimos no seu navegador. Volte aqui quando terminar.',
+        sair: 'Sair',
+        sessaoExpirada: 'Sessão expirada',
+        // A mensagem de erro vem pronta do main (critério 6) e é exibida como veio;
+        // esta chave é só o rótulo da região que a apresenta.
+        falha: 'Não foi possível entrar',
+        tentarNovamente: 'Tentar novamente',
+        conta: 'Conta conectada'
+      },
       erro: {
         espaco: 'Não foi possível carregar o espaço de trabalho.',
         trocaEspaco: 'Não foi possível alternar o espaço de trabalho.',
@@ -92,6 +107,19 @@ export const RECURSOS = {
         temaEscuro: 'Dark',
         temaSistema: 'System',
         salvo: 'Preferences saved.'
+      },
+      auth: {
+        titulo: 'JARVIS OS',
+        subtitulo: 'Sign in with your Google account to get started.',
+        entrar: 'Sign in with Google',
+        entrando: 'Waiting for the browser…',
+        entrandoDescricao:
+          'We opened a tab in your browser to finish signing in. Come back here when you are done.',
+        sair: 'Sign out',
+        sessaoExpirada: 'Session expired',
+        falha: 'Could not sign in',
+        tentarNovamente: 'Try again',
+        conta: 'Connected account'
       },
       erro: {
         espaco: 'Could not load the workspace.',

--- a/src/shared/contracts/auth.ts
+++ b/src/shared/contracts/auth.ts
@@ -1,0 +1,88 @@
+/**
+ * Contrato de autenticação (SPEC-Fundacao-03).
+ *
+ * Mora em `src/shared` pelo mesmo motivo dos demais contratos: renderer, main e testes
+ * falam a mesma língua, e a regra precisa ser verificável sem carregar o Electron.
+ *
+ * A fronteira que este arquivo existe para manter (critério 4 da spec): **nenhum tipo
+ * daqui carrega token**. O que o renderer enxerga é o `AuthSnapshot` — estado + perfil.
+ * O segredo vive cifrado no `safeStorage`/DPAPI, alcançável só pelo main; não há tipo
+ * aqui que o descreva, justamente para que não exista caminho tipado até ele.
+ */
+
+import type { UserProfile } from '../domain/entities'
+
+/**
+ * Estados explícitos de auth (SPEC-03 § Escopo).
+ *
+ * `sessao-expirada` é distinto de `deslogado` de propósito: o usuário tinha sessão e ela
+ * venceu — a UI precisa dizer isso e oferecer reautenticar, em vez de tratar como quem
+ * nunca entrou. `erro` guarda a falha do fluxo, que é recuperável por nova tentativa.
+ */
+export const AUTH_STATES = [
+  'deslogado',
+  'autenticando',
+  'ativo',
+  'erro',
+  'sessao-expirada'
+] as const
+
+export type AuthState = (typeof AUTH_STATES)[number]
+
+export function isAuthState(value: unknown): value is AuthState {
+  return typeof value === 'string' && (AUTH_STATES as readonly string[]).includes(value)
+}
+
+/**
+ * Janela de operação offline: 30 dias sem revalidação online (decisão do PI, questão
+ * aberta 2 do ADR-001). Passado isso, o app exige reautenticação mesmo com token em disco.
+ */
+export const OFFLINE_SESSION_MAX_DAYS = 30
+
+/**
+ * O que o renderer vê sobre a autenticação. É o contrato completo do lado da UI.
+ *
+ * `profile` é o snapshot mínimo da spec (nome, e-mail, idioma) e vem do `UserProfile` da
+ * F04 — sem token, sem id de provedor, sem claim do JWT. `mensagem` carrega texto pronto
+ * para exibir: o critério 6 proíbe stack trace na UI, então quem formata é o main, e o
+ * renderer só pinta o que recebe.
+ */
+export interface AuthSnapshot {
+  readonly state: AuthState
+  /** Presente apenas em `ativo` — nos demais estados não há usuário para mostrar. */
+  readonly profile?: UserProfile
+  /** Frase curta em pt-BR para a UI. Sem stack, sem detalhe técnico (critério 6). */
+  readonly mensagem?: string
+  /** ISO-8601 do vencimento da janela offline. Deixa a UI avisar antes de expirar. */
+  readonly expiresAt?: string
+}
+
+/** Snapshot de quem ainda não entrou. Constante para os call sites não remontarem o objeto. */
+export const DESLOGADO: AuthSnapshot = { state: 'deslogado' }
+
+/**
+ * Motivos de falha do fluxo, na forma que o main resolve para mensagem.
+ *
+ * Enum fechado em vez de string livre: a mensagem exibida precisa ser previsível e
+ * traduzível, e um `error.message` cru vindo do Supabase ou da rede é exatamente o
+ * vazamento de detalhe técnico que o critério 6 proíbe.
+ */
+export const AUTH_ERROS = [
+  'sem-conexao',
+  'cancelado-pelo-usuario',
+  'credenciais-ausentes',
+  'falha-no-provedor',
+  'sessao-expirada'
+] as const
+
+export type AuthErro = (typeof AUTH_ERROS)[number]
+
+/** Mensagens da UI por motivo. pt-BR, curtas, sem jargão e sem stack (critério 6). */
+export const AUTH_MENSAGENS: Readonly<Record<AuthErro, string>> = {
+  'sem-conexao': 'Sem conexão com a internet. Verifique a rede e tente entrar de novo.',
+  'cancelado-pelo-usuario': 'Login cancelado.',
+  'credenciais-ausentes':
+    'O aplicativo não está configurado para login. Verifique as credenciais no arquivo .env.',
+  'falha-no-provedor': 'Não foi possível concluir o login com o Google. Tente novamente.',
+  'sessao-expirada': 'Sua sessão expirou. Entre novamente para continuar.'
+}

--- a/src/shared/contracts/ipc.ts
+++ b/src/shared/contracts/ipc.ts
@@ -16,6 +16,7 @@ import type {
   UserPreferences,
   WorkspaceId
 } from '../domain/entities'
+import type { AuthSnapshot } from './auth'
 import type { LogInput } from './logging'
 
 /** Canais de request/response (renderer → main → renderer). */
@@ -37,7 +38,17 @@ export const IPC_CHANNELS = {
   /** Preferências do usuário corrente + o tema já resolvido (SPEC-05). */
   preferencesGet: 'preferences:get',
   /** Grava idioma e/ou tema. Ação de baixo risco: **não** gera AuditEvent (SPEC-05). */
-  preferencesSave: 'preferences:save'
+  preferencesSave: 'preferences:save',
+  /** Estado corrente da autenticação. Nunca devolve token (SPEC-03, critério 4). */
+  authGet: 'auth:get',
+  /**
+   * Inicia o login Google. O fluxo abre no **navegador do sistema** e retorna por um
+   * servidor loopback local (decisão do PI na SPEC-03) — nunca em webview do Electron,
+   * onde o app enxergaria as credenciais digitadas pelo usuário.
+   */
+  authLogin: 'auth:login',
+  /** Revoga a sessão, apaga os tokens e volta para `deslogado` (critério 3). */
+  authLogout: 'auth:logout'
 } as const
 
 /**
@@ -57,9 +68,23 @@ export const IPC_SEND_CHANNELS = {
   windowMinimizeToTray: 'window:minimizar-tray'
 } as const
 
+/**
+ * Canais de push (main → renderer). O renderer assina; não pede.
+ *
+ * Existe porque o login não é request/response: o usuário sai para o navegador e volta
+ * minutos depois, e a sessão pode expirar sozinha durante o uso. Sem push, a UI teria de
+ * ficar consultando `auth:get` em intervalo — polling que gasta e ainda chega atrasado.
+ */
+export const IPC_EVENT_CHANNELS = {
+  /** Novo `AuthSnapshot` a cada transição de estado. Nunca carrega token. */
+  authChanged: 'auth:changed'
+} as const
+
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS]
 
 export type IpcSendChannel = (typeof IPC_SEND_CHANNELS)[keyof typeof IPC_SEND_CHANNELS]
+
+export type IpcEventChannel = (typeof IPC_EVENT_CHANNELS)[keyof typeof IPC_EVENT_CHANNELS]
 
 /** Informação pública do app exposta ao renderer. */
 export interface AppInfo {
@@ -123,6 +148,18 @@ export interface JarvisBridge {
   getPreferences(): Promise<PreferencesSnapshot>
   /** Grava e devolve o estado resultante, já com o tema resolvido. */
   savePreferences(preferences: UserPreferences): Promise<PreferencesSnapshot>
+
+  /** Estado corrente da auth. Só estado e perfil — token não atravessa a ponte. */
+  getAuth(): Promise<AuthSnapshot>
+  /** Dispara o login; o resultado chega pelo `onAuthChanged`, não pelo retorno. */
+  login(): Promise<AuthSnapshot>
+  logout(): Promise<AuthSnapshot>
+  /**
+   * Assina as transições de auth. Devolve a função que cancela a assinatura — sem ela o
+   * listener sobreviveria ao componente que o registrou e vazaria a cada remontagem.
+   */
+  onAuthChanged(listener: (snapshot: AuthSnapshot) => void): () => void
+
   /** Pede ao main para minimizar a janela para o tray. */
   minimizeToTray(): void
 }

--- a/tests/e2e/login.e2e.ts
+++ b/tests/e2e/login.e2e.ts
@@ -15,6 +15,9 @@ import { _electron as electron, expect, test, type ElectronApplication } from '@
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+// O pacote `electron` exporta o caminho do binário; o .d.ts descreve a API do runtime,
+// daí o duplo cast — em Node, o valor É uma string.
+import electronPath from 'electron'
 
 let app: ElectronApplication
 let userData: string
@@ -31,7 +34,22 @@ test.beforeEach(async () => {
   const ambiente = { ...process.env }
   delete ambiente.ELECTRON_RUN_AS_NODE
 
+  /**
+   * `executablePath` explícito NÃO é cosmético — é o que desativa o loader que o
+   * Playwright injeta (`-r loader.js`) quando resolve o Electron sozinho. Esse loader
+   * aplica os switches de teste do Chromium ao main process, entre eles
+   * `--password-store=basic`: no Linux isso força o os_crypt pro backend `basic_text`,
+   * `safeStorage.isEncryptionAvailable()` responde false, e o boot falha alto por
+   * desenho (ADR-004) — a janela nunca nasce e o E2E morre em "timeout esperando
+   * window", com o keyring do CI perfeitamente funcional ao lado.
+   *
+   * `chromiumSandbox: true` impede o `--no-sandbox` que o launcher acrescenta por
+   * padrão no Linux — o sandbox do renderer é critério de aceite da SPEC-Fundacao-03,
+   * e um E2E que o desliga passaria exatamente onde deveria provar a fronteira.
+   */
   app = await electron.launch({
+    executablePath: electronPath as unknown as string,
+    chromiumSandbox: true,
     args: ['.', `--user-data-dir=${userData}`],
     env: {
       ...ambiente,

--- a/tests/e2e/login.e2e.ts
+++ b/tests/e2e/login.e2e.ts
@@ -42,6 +42,13 @@ test.beforeEach(async () => {
       SUPABASE_PUBLISHABLE_KEY: ''
     }
   })
+
+  // O reporter engole o stderr do processo principal, e todo erro de boot no CI
+  // (sandbox, keyring, display) aparece como um mudo "timeout esperando window".
+  // Ecoar aqui é o que transforma esses timeouts em erro legível no log.
+  app.process().stderr?.on('data', (chunk: Buffer) => {
+    console.error(`[electron stderr] ${chunk.toString().trimEnd()}`)
+  })
 })
 
 test.afterEach(async () => {

--- a/tests/e2e/login.e2e.ts
+++ b/tests/e2e/login.e2e.ts
@@ -1,0 +1,135 @@
+/**
+ * E2E do fluxo de login no app Electron real (SPEC-Fundacao-03, critério 9).
+ *
+ * O que só este teste prova, e nenhum unitário provaria: que `contextIsolation` ligado,
+ * preload, canais IPC, janela e renderer funcionam **juntos**. Os testes de componente
+ * rodam contra uma ponte dublada; aqui a ponte é a de verdade.
+ *
+ * O provedor externo fica fora: a tela de consentimento do Google é HTML de terceiro, e
+ * automatizá-la produz teste que quebra quando eles mudam o layout — sem dizer nada sobre
+ * o nosso app. O recorte é o fluxo **até** o navegador abrir, mais a prova de que a
+ * fronteira de segurança se sustenta com o app rodando.
+ */
+
+import { _electron as electron, expect, test, type ElectronApplication } from '@playwright/test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+let app: ElectronApplication
+let userData: string
+
+test.beforeEach(async () => {
+  // `userData` isolado por execução: o app guarda SQLite, logs e cofre ali, e reaproveitar
+  // o diretório do desenvolvedor faria o teste ler a sessão real de quem o roda.
+  userData = mkdtempSync(join(tmpdir(), 'jarvis-e2e-'))
+
+  // `ELECTRON_RUN_AS_NODE` herdado do shell faz o Electron subir como Node puro — o
+  // import de `electron` some e o erro aparece como "does not provide an export named
+  // BrowserWindow", que parece falha de bundle e não é. Limpar aqui torna o E2E
+  // independente do ambiente de quem o roda.
+  const ambiente = { ...process.env }
+  delete ambiente.ELECTRON_RUN_AS_NODE
+
+  app = await electron.launch({
+    args: ['.', `--user-data-dir=${userData}`],
+    env: {
+      ...ambiente,
+      NODE_ENV: 'development',
+      // Sem credenciais o app sobe no estado "login indisponível", que é justamente um dos
+      // caminhos que a spec exige tratar — e mantém o E2E offline e determinístico.
+      SUPABASE_URL: '',
+      SUPABASE_PUBLISHABLE_KEY: ''
+    }
+  })
+})
+
+test.afterEach(async () => {
+  /**
+   * Encerra com `app.exit()`, não com `close()` nem `quit()`. Os dois travam aqui, por
+   * duas razões que se somam:
+   *
+   * 1. O app **vive no tray**: `window-all-closed` é deliberadamente vazio (SPEC-02),
+   *    então fechar a janela não encerra o processo — `close()` espera um `exit` que
+   *    nunca vem e deixa a janela aberta na tela de quem roda a suíte.
+   * 2. `quit()` dispara `will-quit`, que fecha o logger; os timers de rotação do
+   *    `winston-daily-rotate-file` seguram o event loop e o processo continua vivo.
+   *
+   * `exit()` encerra sem esperar handles pendentes (~200ms, medido). É adequado porque o
+   * `userData` é descartável: não há estado a preservar, e o desligamento gracioso é
+   * coberto pelos testes de unidade — não é o que este E2E investiga.
+   */
+  await app?.evaluate(({ app: electronApp }) => electronApp.exit(0)).catch(() => undefined)
+  await app?.close().catch(() => undefined)
+
+  rmSync(userData, { recursive: true, force: true })
+})
+
+test('o app sobe na tela de entrada e não expõe o shell sem sessão', async () => {
+  const janela = await app.firstWindow()
+  await janela.waitForLoadState('domcontentloaded')
+
+  // A porta de entrada aparece…
+  await expect(janela.getByRole('heading', { name: 'JARVIS OS' })).toBeVisible()
+  // …e o shell não: quem não entrou não alcança espaços nem navegação. Esta é a asserção
+  // que só o E2E consegue fazer com preload e IPC reais no circuito.
+  await expect(janela.getByRole('radiogroup')).toHaveCount(0)
+  await expect(janela.getByRole('navigation')).toHaveCount(0)
+})
+
+test('a ponte expõe só o contrato — sem ipcRenderer, sem token (critério 4)', async () => {
+  const janela = await app.firstWindow()
+  await janela.waitForLoadState('domcontentloaded')
+
+  const superficie = await janela.evaluate(() => {
+    const ponte = (globalThis as unknown as { jarvis: Record<string, unknown> }).jarvis
+    return {
+      metodos: Object.keys(ponte).sort(),
+      // O renderer não pode alcançar Node nem o ipcRenderer cru com a fronteira ligada.
+      temRequire: typeof (globalThis as unknown as { require?: unknown }).require,
+      temProcess: typeof (globalThis as unknown as { process?: unknown }).process
+    }
+  })
+
+  expect(superficie.metodos).toEqual([
+    'getAppInfo',
+    'getAuth',
+    'getPreferences',
+    'getWorkspace',
+    'listAuditEvents',
+    'login',
+    'logout',
+    'minimizeToTray',
+    'onAuthChanged',
+    'savePreferences',
+    'sendLog',
+    'switchWorkspace',
+    'verifyAuditChain'
+  ])
+
+  // Nenhum método entrega credencial — a superfície fechada é o critério 4 em runtime.
+  expect(superficie.metodos.some((m) => /token|secret|session|credential/i.test(m))).toBe(false)
+  expect(superficie.temRequire).toBe('undefined')
+  expect(superficie.temProcess).toBe('undefined')
+})
+
+test('sem credenciais configuradas, avisa com mensagem clara (critério 6)', async () => {
+  const janela = await app.firstWindow()
+  await janela.waitForLoadState('domcontentloaded')
+
+  // O app já **nasce** neste estado: sem `.env`, o `auth:get` do boot responde o erro de
+  // credenciais ausentes, então o aviso aparece sem o usuário tentar nada — e o botão
+  // convida a repetir, não a iniciar.
+  const alerta = janela.getByRole('alert')
+  await expect(alerta).toBeVisible()
+  await expect(alerta).toContainText(/\.env/)
+  await expect(janela.getByRole('button', { name: /tentar novamente/i })).toBeVisible()
+
+  // Mensagem de produto, em pt-BR: sem stack trace, sem nome de arquivo, sem "Error:".
+  const texto = (await alerta.textContent()) ?? ''
+  expect(texto).not.toMatch(/\bat\s|\.ts:\d+|Error:/)
+
+  // Repetir sem credenciais mantém o aviso — e não derruba o app.
+  await janela.getByRole('button', { name: /tentar novamente/i }).click()
+  await expect(alerta).toBeVisible()
+})

--- a/tests/e2e/login.e2e.ts
+++ b/tests/e2e/login.e2e.ts
@@ -49,6 +49,11 @@ test.beforeEach(async () => {
   app.process().stderr?.on('data', (chunk: Buffer) => {
     console.error(`[electron stderr] ${chunk.toString().trimEnd()}`)
   })
+  // O logger do app (winston, console ligado fora de produção) escreve no stdout —
+  // é onde a promise rejeitada do boot aparece.
+  app.process().stdout?.on('data', (chunk: Buffer) => {
+    console.error(`[electron stdout] ${chunk.toString().trimEnd()}`)
+  })
 })
 
 test.afterEach(async () => {


### PR DESCRIPTION
Fatia 03 do MVP-001. Spec: [`docs/spec/spec-fundacao-03-auth-google.md`](docs/spec/spec-fundacao-03-auth-google.md) — `aprovada-pi` (2026-07-21, emendada em 2026-07-22). Sustentada por ADR-001 (local-first) e ADR-002 (OAuth via projeto Supabase de dev).

**Desbloqueada hoje:** o PI criou o projeto Supabase, registrou o cliente OAuth do Google Cloud e preencheu o `.env`. Com isso a fatia saiu no mesmo dia e **o MVP-001 fecha em 6/6 entregues**.

refs #4

## O que entra

**Fluxo de autenticação (main process)**
- OAuth **PKCE** via Supabase Auth, aberto no **navegador do sistema** — nunca em webview do Electron, onde o app enxergaria o formulário de senha do usuário.
- Retorno por **servidor loopback efêmero** (`127.0.0.1`, porta escolhida pelo SO, atende uma requisição e morre). Porta aberta ociosa num app desktop é superfície de ataque sem contrapartida.
- **Sessão offline de 30 dias** (ADR-001, questão aberta 2): dentro da janela, relançar sem internet entra direto e audita `login-offline-reuse`; fora dela, exige reautenticação e limpa o cofre.
- **Logout** revoga no servidor quando dá e **sempre** limpa o local — a limpeza não pode depender da rede, senão o usuário fica preso numa sessão que pediu para encerrar.

**Fronteira de segurança**
- Tokens cifrados com `safeStorage`/DPAPI. O refresh token nunca toca o disco em claro.
- O renderer recebe `AuthSnapshot` (estado + perfil) e nada mais: **não existe tipo no contrato que descreva um token**, logo não há caminho tipado até a credencial.
- Mensagens de erro vêm de um **enum fechado**; um `error.message` cru do Supabase ou da rede nunca chega à tela.

**Integração com o que já existia**
- `WorkspaceService` e os handlers IPC passam a resolver o `user_id` **por função**: a identidade deixou de ser fixa (local antes do login, sessão depois). Capturar a string no boot congelaria o escopo da auditoria no usuário local para sempre.
- Categoria de log `auth` instrumentada (emenda do PI), com redaction comprovada por teste.

## Critérios de aceite

| # | Critério | Onde se prova |
|---|---|---|
| 1 | Login completa; app mostra nome/e-mail | `auth-service.int-spec` (login dirigido ponta a ponta) + `TelaLogin.test` |
| 2 | Relançar **sem internet** com sessão válida entra sem novo login | `auth-service.int-spec` — o Supabase dublado **estoura se for chamado** |
| 3 | Logout limpa tokens e estado sensível | `auth-service.int-spec` (com e sem rede) + `TelaLogin.test` |
| 4 | Renderer nunca vê tokens | `preload.spec` + `login.e2e` (superfície da ponte em runtime) |
| 5 | Cada transição gera `AuditEvent` com timestamp e user_id | `auth-service.int-spec` |
| 6 | Erros com mensagem clara, sem stack trace | `TelaLogin.test` + `login.e2e` |
| 7 | Tokens cifrados no disco | `token-vault.spec` — **lê os bytes do arquivo**; um teste de write/read passaria mesmo gravando em texto puro |
| 8 | Log de `auth` com redaction comprovada | `auth-service.int-spec` varre todos os registros atrás de access/refresh token |
| 9 | `test`/`lint` verdes + **E2E Playwright-Electron** | abaixo |

## Testes

**185 no total** (153 → 182 no Vitest, mais 3 E2E). Zero falhas.

| Categoria | Testes | Cobertura |
|---|---:|---:|
| Regras de Negócio | 92 | 79.6% |
| Banco | 60 | 87.0% |
| Tela | 33 | 93.5% |

**A categoria E2E deixa de contar 0** (ADR-003): o Playwright-Electron sobe o app empacotado e prova, com preload e IPC reais, que o shell não monta sem sessão e que a ponte não expõe caminho até o token — asserções que nenhum teste de componente com ponte dublada consegue fazer.

## Decisões que o PI deve conhecer

1. **O `GOOGLE_OAUTH_CLIENT_SECRET` do `.env` não é lido pelo app.** No desenho do ADR-002 quem fala com o Google é o Supabase; o secret vive no painel dele. Um secret embarcado em app desktop distribuído não é segredo — qualquer usuário o extrai do binário. Decisão do PI (2026-07-22): manter a variável sem uso; o `.env.example` agora explica o porquê.
2. **`findMostRecent()` é a única consulta sem escopo de `user_id`**, documentada no próprio método. No boot o app precisa descobrir *de quem* é a sessão do cofre, e perguntar isso já sabendo o `user_id` seria circular. O isolamento se mantém porque o login apaga as sessões anteriores. A alternativa — decodificar o JWT — faria o app confiar no conteúdo de um token que quem valida é o Supabase.
3. **Teardown do E2E usa `app.exit()`.** `close()` e `quit()` travam, por comportamento **correto** do produto: o app vive no tray (`window-all-closed` vazio, SPEC-02) e os timers do `winston-daily-rotate-file` seguram o event loop no `will-quit`. Registrado em `docs/TESTING.md` §3.1 junto com as outras duas armadilhas de ambiente que custaram diagnóstico (`ELECTRON_RUN_AS_NODE` herdado e instâncias remanescentes vs. `requestSingleInstanceLock`).

## CI

`ci.yml` instala as libs de sistema do Playwright e roda o relatório sob `xvfb`; a guarda de carimbo passa a reconhecer `*.e2e.ts`. `workers: 1` no Playwright é obrigatório, não preferência — a instância única faz execuções paralelas se derrubarem.

## Plano de teste

- [x] `npm run lint` — verde
- [x] `npm run typecheck` — verde
- [x] `npm run test` — 182/182
- [x] `npx playwright test` — 3/3
- [x] `npm run test:report:check` — números batem, histórico íntegro
- [ ] **PI:** login real com a conta Google, conferir nome/e-mail no header
- [ ] **PI:** fechar o app, desligar a rede, reabrir → deve entrar direto
- [ ] **PI:** logout → volta para a tela de entrada

> Merge integra o código; **não** é aceite. A issue #4 permanece aberta para o PI fechar com `proplan:finalizado`. Com ela aceita — junto de #2, #3, #5 e #6 — o épico **#1 (MVP-001) pode fechar**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)