### PR TITLE
[INFRA] CLAUDE.md: explicita que o PI não cria issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Desktop app **local-first** (Electron + React + TypeScript) com dois espaços de
 
 ## Papéis e governança
 
-- **Rodrigo Reis (PI)** — decide escopo, prioridades e trade-offs; aprova specs e aceita entregas.
+- **Rodrigo Reis (PI)** — decide escopo, prioridades e trade-offs; aprova specs e aceita entregas, não cria issue.
 - **Claude Cowork (planejamento)** — especifica e mantém `docs/` e as specs em `docs/specs/`. Antes de finalizar qualquer spec, apresenta as perguntas abertas e dúvidas ao PI — spec só vira `aprovada-pi` com todas resolvidas (evitar retrabalho). Quando a spec vira `aprovada-pi`, **cria a issue-fatia no board** (coluna Backlog, assignee PI). **Nunca implementa código** — implementação é exclusiva do Claude Code.
 - **Claude Code (você)** — planeja, codifica, testa (código, UX e UI — pode usar as skills do impeccable), atualiza a documentação e **sempre commita todos os documentos de `docs/`** junto da entrega. Implementa a partir deste arquivo + `docs/` + spec da feature em `docs/specs/`. **Não cria a issue** (é do Cowork) — pega o card, move pelo fluxo e entrega com PR. Pode criticar arquitetura, **não escopo**. Sem spec para a tarefa, ou spec ambígua → perguntar ao PI antes de codificar, nunca assumir. Deve apontar problemas técnicos da spec — a correção passa pelo PI.
 


### PR DESCRIPTION
## O que muda

Uma linha no `CLAUDE.md`, na seção **Papéis e governança**: acrescenta "não cria issue" ao papel do PI.

## Por quê

O papel do PI já dizia o que ele **faz** — decide escopo, aprova specs, aceita entregas. Faltava dizer o que **não** é dele. A criação de issue já estava atribuída em outros pontos do documento:

- **fatia** → Cowork cria quando a spec vira `aprovada-pi`;
- **correção de bug documentado** → o próprio Code cria o card `[FIX]`.

Sem a linha, a leitura mais natural era que o dono também abriria os cards — o que contradiz as duas regras acima.

## Escopo

Só documentação. Nenhum código, nenhum teste, nenhuma mudança de comportamento — por isso o `reports/TESTS.md` não muda (a guarda de carimbo só exige entrada de histórico quando o PR altera teste).

---

Sem `refs #N`: não há issue para esta mudança. É ajuste de processo no próprio contrato, não fatia nem correção de bug documentado.