### PR TITLE
[MVP3][F03a] Componentes: ações + formulários

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,22 @@ jobs:
           npm run lint
           npm run typecheck
 
+      # Prova visual dos controles (SPEC-DesignSystem-03a): sobe a galeria num Chromium de
+      # verdade e mede o que jsdom não mede — altura real dos controles, contraste computado,
+      # fontes carregadas, anel de foco pintado.
+      #
+      # Roda **antes** da bateria pesada porque é barata (~5s) e pega classe de defeito que
+      # nenhum teste de papel pega: na própria 03a encontrou o CSS dos componentes não sendo
+      # gerado e o card do NOA invertido, com os 91 testes de componente verdes nos dois casos.
+      #
+      # `--with-deps chromium` e não o browser inteiro: só o Chromium é usado aqui, e o
+      # Electron do E2E já tem as libs de sistema instaladas no step acima.
+      - name: Instalar o Chromium do Playwright (galeria de prova)
+        run: npx playwright install --with-deps chromium
+
+      - name: Prova visual dos controles
+        run: npm run test:prova
+
       # SPEC-Execucao-01, critério 6: o int-spec de RLS exercita a stack real, então o CI
       # a sobe. Sem este step o arquivo **passaria pulando** — os testes se pulam quando a
       # stack não responde (para não punir quem clona sem Docker), e o CI ficaria verde

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 node_modules
 out
 dist
+# Capturas da galeria de prova (SPEC-DesignSystem-03a): artefato regerável por
+# `npx playwright test --config playwright.prova.config.ts`, como o coverage. Versioná-las
+# faria o repo carregar PNG que muda a cada ajuste de pixel, sem ninguém revisar o diff.
+reports/prova/
+
 coverage
 *.log
 *.tsbuildinfo

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Office3D: abrir sala",
+      "type": "shell",
+      "command": "office3d start",
+      "problemMatcher": [],
+      "runOptions": {
+        "runOn": "folderOpen"
+      },
+      "presentation": {
+        "reveal": "never"
+      }
+    }
+  ]
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -304,6 +304,38 @@ Status: **entregue** — spec `aprovada-pi` (2026-07-21); issue [#18](https://gi
 6. **`reduced-motion` zera a duração no token**, não em cada animação — quem anima lê `--jos-duracao-*`, então anular a variável desliga a árvore toda. Caçar `animation` por componente deixaria passar o próximo que alguém escrever. `0.01ms` e não `0`: duração zero cancela `transitionend` e travaria componente que espera esse evento.
 7. **A fronteira da F01 pegou o teste desta fatia.** `node:fs` importado em `src/design/` — o lint barrou. Corrigido importando o JSON como módulo, não abrindo exceção: se a regra cedesse para teste, viraria "vale exceto quando incomoda". A regra da fatia anterior mordendo o autor dela é o melhor sinal de que é real.
 
+### Fatia 03a — Componentes: ações + formulários (`docs/spec/spec-design-system-03a-componentes-acoes-forms.md`)
+
+Status: **entregue** — spec `aprovada-pi` (2026-07-21); issue [#19](https://github.com/RodReis/rrb-jarvisOS/issues/19); PR [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42). Depende da F01 (Radix + fronteira) e da F02 (tokens). Pode andar em paralelo com a 03b.
+
+- [x] **Ações** (PRD §11.1): `Button` (primária/secundária/perigo), `IconButton`, `ButtonGroup`, `Link`
+- [x] **Campos** (PRD §11.2): `Field`, `FormMessage`, `Input`, `PasswordInput`, `Textarea`
+- [x] **Radix encapsulado**: `Select`, `Checkbox`, `RadioGroup`, `Slider`, `Alternador` (Switch)
+- [x] **`Combobox` próprio** — padrão ARIA completo; o Radix não publica um
+- [x] `ui/base.ts`: altura única (44px), foco, borda, transição, estado desabilitado
+- [x] Estado nunca só por cor — inclusive **entre variantes** (correção do critique)
+- [x] Regra de lint do critério 5: componentes consomem só tokens
+- [x] **Galeria de prova visual** + 8 asserções num navegador real
+- [x] Entrega: PR [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42) (`refs #19`); docs/ commitados
+
+**Decisões técnicas desta fatia:**
+
+1. **A gramática visual foi derivada do protótipo, não inventada.** Só **3 dos 16** componentes têm tela de referência (Input, Button primário e secundário, da tela de login); as outras 41 telas são de exibição. Decisão do PI: extrair o vocabulário do que existe — 44px, raio de card, borda de baixo alfa, label mono UPPERCASE, foco no acento — e concentrá-lo em `ui/base.ts`. Inventar estética a cada arquivo produziria 16 dialetos.
+2. **A hierarquia de ação é preenchimento, não matiz.** A primeira versão distinguia as variantes só por cor. Com `#C4C4C4` (default do NOA) ou `#FFFFE3` — ambos na paleta de 8 que o usuário escolhe —, primária, carregando e desabilitado renderizavam como o **mesmo botão cinza**. O sistema aplicava "estado nunca só por cor" dentro de cada componente (check, alça, ponto) e violava a regra uma camada acima. Agora primária é sólida e pesada; perigo, contornada e pesada — peso e preenchimento sobrevivem a qualquer acento.
+3. **As semânticas ganharam variante de leitura.** Como texto no modo claro, as cinco falhavam a régua: `err` 2.53:1, `violet` 2.52, `warn` 1.99, `ok` 1.78, `info` 1.54. Foram desenhadas para fundo escuro. A cor de marca segue intacta em borda, ícone e preenchimento; só o texto lê da variante ajustada — o mesmo mecanismo que o acento já usava desde a F02.
+4. **`textMuted` corrigido, e fidelidade cedeu à legibilidade.** `#6b7382` media 4.08–4.12:1 no escuro, e o token não é decorativo: carrega placeholders, texto de apoio e **todas as labels** (via `LABEL_MONO`, em `--jos-texto-micro` com uppercase — texto pequeno, sem isenção). `#757d8c` é o desvio mínimo que atinge 4.5:1. É o princípio 1 do PRODUCT.md ("clareza antes de efeito visual") decidindo contra o protótipo.
+5. **`Field` devolve os atributos ARIA por render prop.** Cada componente montar o próprio `aria-describedby` é a via para um esquecer. O erro precede a descrição na ordem de leitura: quem acabou de errar precisa ouvir o problema antes da instrução genérica.
+6. **`ButtonGroup papel="segmentado"` foi removido, não remendado.** Prometia `role="radiogroup"` sobre filhos `<button>` — o leitor de tela anunciaria um grupo de rádio **sem rádios dentro**, pior que a fileira de botões que a variante tentava corrigir. Um controle segmentado de verdade precisa de estado e navegação por setas; é escopo da F04a, onde há tela que o use. Entregar a casca seria oferecer acessibilidade inexistente.
+7. **`Combobox` fecha por `focusout`, não por timer.** A versão inicial usava `setTimeout(…, 120)` para o `mousedown` da opção registrar antes do fechamento: o timer nunca era limpo (disparava após o unmount) e, sob quadro lento, a lista fechava antes do clique. `relatedTarget` responde a pergunta certa — "o foco saiu daqui?" — sem constante para calibrar.
+8. **Três camadas de verificação, cada uma pegando o que a anterior não pega.** Os 91 testes de papel acharam o `aria-label` no `Root` do slider em vez do `Thumb` (a faixa ficava anônima). A **prova visual** achou dois defeitos com esses 91 verdes: o CSS dos componentes não estava sendo gerado (o Tailwind v4 varre a partir da `root` do Vite, e `../ui` ficava fora) e o card do NOA estava invertido (`nt16` é cor de **texto** — os índices `jt`/`nt` são independentes, não numerações paralelas). O **`/impeccable critique`** achou os 10 itens de contraste e hierarquia. Cada correção deixou teste que a trava, verificado por mutação.
+
+**Registrado, não silenciado:**
+
+- `RadioGroup` por setas **não é verificável em jsdom** (roving tabindex do Radix depende de foco real). `it.todo` com a razão escrita, em vez de um teste que passa medindo outra coisa — cobre-se no E2E da F04a.
+- A galeria cobre **4 de 32** combinações de acento. Os dois defeitos apareceram nos defaults; ampliar a matriz é candidato para a F06.
+- **`:active` não existe em nenhum dos 16** — nenhum controle dá feedback de pressão. Anotado para a F06 (hardening).
+- Card **[#41](https://github.com/RodReis/rrb-jarvisOS/issues/41)**: o renderer sobe em porta variável, contra o `strictPort` do CLAUDE.md. Achado ao subir o app para inspeção; não misturado na fatia.
+
 ## Após o MVP-003
 
 Ordem: **MVP-004** ([#10](https://github.com/RodReis/rrb-jarvisOS/issues/10), execução real + terminal) → MVP de providers (Corte 3, com BudgetPolicy). Ordem macro em `docs/LANDSCAPE.md` § Roadmap.
@@ -312,6 +344,7 @@ Ordem: **MVP-004** ([#10](https://github.com/RodReis/rrb-jarvisOS/issues/10), ex
 
 | Data | Fatia | PR | Observação |
 |---|---|---|---|
+| 2026-07-23 | MVP-003 · F03a Componentes: ações + formulários (#19) | [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42) | Regras 203 (78.2%), Banco 117 (87.5%), Tela 95 (89.6%) — **+85 testes**. Os 16 componentes de ação e formulário. A fatia introduziu **três camadas de verificação**, e cada uma pegou o que a anterior não pegava: os testes de papel acharam o `aria-label` no lugar errado do slider; a **prova visual** achou o CSS não sendo gerado e o card do NOA invertido, **com os 91 testes de papel verdes**; o **`/impeccable critique`** achou 10 itens de contraste e hierarquia — incluindo a ação primária colapsando com a desabilitada em 2 dos 8 acentos da paleta. A lição que fica é sobre método: o rigor de contraste existia só no caminho do acento (a cor que o *usuário* escolhe) e não nos papéis que *nós* escolhemos. Agora são 41 asserções sobre todos os papéis × 2 módulos × 2 modos. |
 | 2026-07-23 | MVP-003 · F02 Foundations + ponte com o protótipo (#18) | [#40](https://github.com/RodReis/rrb-jarvisOS/pull/40) | Regras 158 (77.9%), Banco 117 (87.5%), Tela 55 (91.2%) — **+42 testes**. A ponte protótipo→código: 71 tokens × 2 modos **extraídos** (determinístico), não transcritos — 142 valores de cor à mão é onde o typo silencioso mora. Duas provas por mutação: sem a exceção da marca, 6 testes vermelhos; sem a regra de fronteira (F01), 6 vermelhos. As 8 cores da paleta × 2 fundos atingem 4.5:1 — paleta fechada permite afirmar sobre **todas**, não amostrar. Fontes baixadas e versionadas (78 KB) porque a CSP do renderer não aceita CDN e falharia em silêncio. Junto: `PRODUCT.md` (contexto de design via `/impeccable init`, a pedido do PI) documentando as **três camadas** — Desenvolvimento não é espaço de usuário. |
 | 2026-07-23 | MVP-003 · F01 Infra do design system (#17) | [#38](https://github.com/RodReis/rrb-jarvisOS/pull/38) | Regras 139 (75.0%), Banco 117 (87.5%), Tela 39 (93.6%) — **+16 testes**. **Abre o MVP-003.** Só esqueleto: três camadas, toolchain e fronteira, sem nenhum token ou componente de produto. O que a fatia realmente entrega é a **fronteira verificável** — `no-restricted-imports` escopada a `src/design/**` que quebra o `lint`, exercitada pelo ESLint real nos dois sentidos e provada por mutação (sem o bloco da regra, 6 casos ficam vermelhos). O teste guarda também o *escopo*: alargar o `files:` por engano quebraria o renderer, então há asserção de que um arquivo fora do DS continua livre para importar `@shared`. `tokens` é testado em `node` e não em jsdom — o ambiente é o que prova "sem React". |
 | 2026-07-22 | MVP-001 · F01 Bootstrap e estrutura (#2) | [#25](https://github.com/RodReis/rrb-jarvisOS/pull/25) | CI verde na 1ª execução. Relatório ADR-003 ativo: selfcheck 10/10, guarda anti-drift verificada nos dois sentidos. Regras 14 (85%), Tela 4 (100%), Banco 0 (F04). |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -9,8 +9,9 @@ Atualizado em: **2026-07-23**. Mantido pelo Code a cada entrega (junto com `DEVE
 | Issue | Fatia | MVP | Spec | Índice |
 |---|---|---|---|---|
 | [#34](https://github.com/RodReis/rrb-jarvisOS/issues/34) | — (`[INFRA]`) | — | *(sem spec — infra)* | — |
+| [#41](https://github.com/RodReis/rrb-jarvisOS/issues/41) | — (`[FIX]`) | MVP-001 | *(sem spec — bug documentado)* | — |
 
-> **`proplan:next` = [#19](https://github.com/RodReis/rrb-jarvisOS/issues/19)** (MVP-003 · F03a Componentes: ações + formulários). O MVP-003 começou em 2026-07-23; **F01 (#17)** e **F02 (#18)** entregues no mesmo dia. Pela ordem do épico, F03a/F03b/F05 podem correr em paralelo — o marcador fica na F03a.
+> **`proplan:next` = [#20](https://github.com/RodReis/rrb-jarvisOS/issues/20)** (MVP-003 · F03b Componentes: dados + overlays + feedback). F01, F02 e F03a entregues em 2026-07-23. Pela ordem do épico, F03b e F05 podem correr em paralelo.
 
 > Card **[#34](https://github.com/RodReis/rrb-jarvisOS/issues/34)** (`[INFRA]`, Backlog): separar o E2E em job de CI próprio, condicional por paths. Criado pelo Code durante a F03 — o cache do Electron (parte fácil) já saiu no PR #35; a separação do E2E do relatório é infra maior e vai em PR dedicado.
 
@@ -21,7 +22,8 @@ Atualizado em: **2026-07-23**. Mantido pelo Code a cada entrega (junto com `DEVE
 | Issue | Fatia | MVP | Spec | Índice | PR | Mergeado |
 |---|---|---|---|---|---|---|
 | [#17](https://github.com/RodReis/rrb-jarvisOS/issues/17) | 01 Infra do design system | MVP-003 (#16) | `spec-design-system-01-infra.md` | M3-F01 | [#38](https://github.com/RodReis/rrb-jarvisOS/pull/38) | 2026-07-23 |
-| [#18](https://github.com/RodReis/rrb-jarvisOS/issues/18) | 02 Foundations + ponte com o protótipo | MVP-003 (#16) | `spec-design-system-02-foundations.md` | M3-F02 | [#40](https://github.com/RodReis/rrb-jarvisOS/pull/40) | *(aguardando)* |
+| [#18](https://github.com/RodReis/rrb-jarvisOS/issues/18) | 02 Foundations + ponte com o protótipo | MVP-003 (#16) | `spec-design-system-02-foundations.md` | M3-F02 | [#40](https://github.com/RodReis/rrb-jarvisOS/pull/40) | 2026-07-23 |
+| [#19](https://github.com/RodReis/rrb-jarvisOS/issues/19) | 03a Componentes: ações + formulários | MVP-003 (#16) | `spec-design-system-03a-componentes-acoes-forms.md` | M3-F03a | [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42) | *(aguardando)* |
 
 > **04 e 02 saíram no mesmo PR**, por decisão do PI (2026-07-22): o critério 4 da SPEC-04 exige `AuditEvent` de `workspace-switch`, cujo fluxo nasce na F02 — separá-las exigiria um stub que a F02 jogaria fora. O critério 4 fica **parcialmente atendido**: `workspace-switch` está provado ponta a ponta; `login`/`logout`/`login-offline-reuse` têm o tipo no contrato e o fluxo nasce na F03.
 
@@ -53,8 +55,8 @@ Atualizado em: **2026-07-23**. Mantido pelo Code a cada entrega (junto com `DEVE
 |---|---|---|---|---|
 | [#17](https://github.com/RodReis/rrb-jarvisOS/issues/17) | 01 Infra do design system | M3-F01 | `spec-design-system-01-infra.md` | **Feito** (PR [#38](https://github.com/RodReis/rrb-jarvisOS/pull/38)) |
 | [#18](https://github.com/RodReis/rrb-jarvisOS/issues/18) | 02 Foundations + ponte com o protótipo | M3-F02 | `spec-design-system-02-foundations.md` | **Feito** (PR [#40](https://github.com/RodReis/rrb-jarvisOS/pull/40)) |
-| [#19](https://github.com/RodReis/rrb-jarvisOS/issues/19) | 03a Componentes: ações + formulários | M3-F03a | `spec-design-system-03a-componentes-acoes-forms.md` | Backlog · **`next`** |
-| [#20](https://github.com/RodReis/rrb-jarvisOS/issues/20) | 03b Componentes: dados + overlays + feedback | M3-F03b | `spec-design-system-03b-componentes-dados-overlays.md` | Backlog |
+| [#19](https://github.com/RodReis/rrb-jarvisOS/issues/19) | 03a Componentes: ações + formulários | M3-F03a | `spec-design-system-03a-componentes-acoes-forms.md` | **Feito** (PR [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42)) |
+| [#20](https://github.com/RodReis/rrb-jarvisOS/issues/20) | 03b Componentes: dados + overlays + feedback | M3-F03b | `spec-design-system-03b-componentes-dados-overlays.md` | Backlog · **`next`** |
 | [#21](https://github.com/RodReis/rrb-jarvisOS/issues/21) | 04a AppShell + navegação | M3-F04a | `spec-design-system-04a-appshell-navegacao.md` | Backlog |
 | [#22](https://github.com/RodReis/rrb-jarvisOS/issues/22) | 04b Padrões operacionais | M3-F04b | `spec-design-system-04b-padroes-operacionais.md` | Backlog |
 | [#23](https://github.com/RodReis/rrb-jarvisOS/issues/23) | 05 Identidades NOA e JARVIS | M3-F05 | `spec-design-system-05-identidades.md` | Backlog |
@@ -72,7 +74,7 @@ Não há catálogo numérico `SPEC-nnn` para o MVP-001: as specs são identifica
 |---|---|---|---|
 | MVP-001 Fundação | [#1](https://github.com/RodReis/rrb-jarvisOS/issues/1) | **fechado** — épico aceito pelo PI em 2026-07-22; todas as 6 filhas `proplan:finalizado` (#2, #3, #4, #5, #6, #8) | **6 / 6** |
 | MVP-002 Execução local controlada (fundação) | [#9](https://github.com/RodReis/rrb-jarvisOS/issues/9) | **fechado** — épico aceito pelo PI em 2026-07-23; todas as 5 filhas `proplan:finalizado` (#15, #11, #12, #13, #14) | **5 / 5** |
-| MVP-003 Design System da Plataforma (base única, 2 identidades) | [#16](https://github.com/RodReis/rrb-jarvisOS/issues/16) | **em andamento** desde 2026-07-23; F01 (#17) e F02 (#18) entregues, aguardando aceite; `next` na F03a (#19) | 0 / 8 *(2 entregues)* |
+| MVP-003 Design System da Plataforma (base única, 2 identidades) | [#16](https://github.com/RodReis/rrb-jarvisOS/issues/16) | **em andamento** desde 2026-07-23; F01, F02 e F03a entregues, aguardando aceite; `next` na F03b (#20) | 0 / 8 *(3 entregues)* |
 | MVP-004 Execução real (terminal + execução allowlisted) | [#10](https://github.com/RodReis/rrb-jarvisOS/issues/10) | renumerado de MVP-003 (título/rótulo atualizados + carimbo); 2 fatias lazy | 0 / 2 |
 | MVP-providers (Corte 3) | — | planejado; incluirá **BudgetPolicy** (modelo decidido no ADR-001 #1) + providers/conectores/RAG | — |
 
@@ -83,11 +85,11 @@ Não há catálogo numérico `SPEC-nnn` para o MVP-001: as specs são identifica
 1. **MVP-001 entregue por inteiro** (2026-07-22): **6 das 6 fatias** — F01 (#2), F06 (#8), F04 (#5), F02 (#3), F05 (#6) e F03 (#4). Ordem executada: **01 → 06 → 04+02 → 05 → 03**. A F03 destravou quando o PI criou as credenciais e saiu no mesmo dia. O `proplan:next` avançou para o **MVP-002** (#9), começando pela F01 (#15), que é independente das demais.
 2. ~~Resolver as "Perguntas ao PI" das specs do MVP-003~~ — **feito** (2026-07-21): as 8 specs estão `aprovada-pi`.
 3. ~~Renumerar #10 → MVP-004 e criar o épico MVP-003 + issues~~ — **feito** (2026-07-21): #10 retitulada MVP-004 (carimbo), épico **#16** criado, 8 filhas **#17–#24** em Backlog e vinculadas.
-4. ~~**Code**: iniciar o MVP-003 pela F01 (#17)~~ — **feito** (2026-07-23): F01 no PR [#38](https://github.com/RodReis/rrb-jarvisOS/pull/38) e **F02 no PR [#40](https://github.com/RodReis/rrb-jarvisOS/pull/40)**, ambas no mesmo dia. Segue com WIP = 1, na ordem (F03a/F03b/F05) → F04a → F04b → F06. **Próxima: F03a (#19)**, marcada `proplan:next`. A partir daqui as fatias são de UI: por decisão do PI (2026-07-23), a skill **impeccable** entra para construir, verificar e polir — sem substituir o piso de `dev`/`test`/`lint` verdes.
+4. ~~**Code**: iniciar o MVP-003 pela F01 (#17)~~ — **feito** (2026-07-23): F01 no PR [#38](https://github.com/RodReis/rrb-jarvisOS/pull/38) e **F02 no PR [#40](https://github.com/RodReis/rrb-jarvisOS/pull/40)**, ambas no mesmo dia. Segue com WIP = 1, na ordem (F03a/F03b/F05) → F04a → F04b → F06. **F03a (#19) entregue** no PR [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42); **próxima: F03b (#20)**. A partir daqui as fatias são de UI: por decisão do PI (2026-07-23), a skill **impeccable** entra para construir, verificar e polir — sem substituir o piso de `dev`/`test`/`lint` verdes.
 5. ~~**PI — desbloqueia a F03 (#4)**~~ — **feito** (2026-07-22): projeto Supabase de dev criado, cliente OAuth do Google Cloud registrado e `.env` preenchido. A fatia foi entregue no mesmo dia ([#30](https://github.com/RodReis/rrb-jarvisOS/pull/30)). *Nota:* o `GOOGLE_OAUTH_CLIENT_SECRET` do `.env` **não é consumido pelo app** — no desenho do ADR-002 quem fala com o Google é o Supabase, e o secret vive no painel dele. Decisão do PI: manter a variável sem uso.
 6. ~~**Code**: MVP-002 F01–F05~~ — **MVP-002 entregue por inteiro** (2026-07-22): F01 [#32](https://github.com/RodReis/rrb-jarvisOS/pull/32), F02 [#33](https://github.com/RodReis/rrb-jarvisOS/pull/33), F03 [#35](https://github.com/RodReis/rrb-jarvisOS/pull/35), F04 [#36](https://github.com/RodReis/rrb-jarvisOS/pull/36), F05 [#37](https://github.com/RodReis/rrb-jarvisOS/pull/37). A F05 fecha o corte: o motor percorre um workflow classificando (F02) e checando allowlist (F03) **sem tocar recurso real** — invariante provado pelo efeito (arquivo não criado, diretório idêntico).
 9. ~~**PI**: decidir a próxima frente~~ — **decidido** (2026-07-23): **MVP-003 Design System** (#16). O card `[INFRA]` **#34** (separar o E2E em job próprio) segue em Backlog e independe do MVP.
-10. **PI**: aceitar a **F01 (#17)** — PR [#38](https://github.com/RodReis/rrb-jarvisOS/pull/38) — e a **F02 (#18)** — PR [#40](https://github.com/RodReis/rrb-jarvisOS/pull/40). Ambas em `proplan:done`, aguardando `proplan:finalizado`.
+10. **PI**: aceitar as fatias entregues do MVP-003 — **F01 (#17)** PR [#38](https://github.com/RodReis/rrb-jarvisOS/pull/38), **F02 (#18)** PR [#40](https://github.com/RodReis/rrb-jarvisOS/pull/40) e **F03a (#19)** PR [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42). Todas em `proplan:done`. O PI pediu (2026-07-23) para **fechar o MVP-003 inteiro antes de testar**, então o aceite pode vir em bloco no fim.
 7. **PI**: (opcional) decidir a adoção de numeração `SPEC-nnn`.
 8. ~~**PI**: aceitar as fatias do MVP-001 e fechar o épico #1~~ — **feito** (2026-07-22): as 6 filhas aceitas (`proplan:finalizado`) e o épico **#1 fechado**. **#15** (MVP-002 · F01) também aceita. **MVP-002 aceito por inteiro** (2026-07-22/23): as 5 filhas `proplan:finalizado` e o épico **#9 fechado**. Dos MVPs 001/002, **nada pendente** — o aceite em aberto agora é a **F01 do MVP-003** (#17), item 10 abaixo.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -78,6 +78,36 @@ export default tseslint.config(
     }
   },
   {
+    // Componentes consomem só tokens (SPEC-DesignSystem-03a, critério 5).
+    //
+    // A camada `ui` é onde o valor solto entra: um `#0a0b0e` ou um `text-[14px]` digitado à
+    // mão funciona, não quebra nada, e desfaz a escala em silêncio. Foi o que a própria 03a
+    // encontrou — `text-[14px]` repetido em sete arquivos antes desta regra existir.
+    //
+    // `tokens/` fica de fora de propósito: é lá que os valores primitivos **devem** morar. A
+    // regra vale para quem os consome, não para quem os define.
+    files: ['src/design/{ui,patterns}/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          // Cor literal em qualquer string: `#rgb`, `#rrggbb`, `rgb(...)`, `hsl(...)`.
+          // `rgba(var(--jos-borda-rgb), .12)` passa — o RGB vem do tema, só o alfa é do uso.
+          selector: 'Literal[value=/#[0-9a-fA-F]{3,8}\\b|\\b(rgb|hsl)a?\\((?![^)]*var\\(--jos)/]',
+          message:
+            'Critério 5 (SPEC-DesignSystem-03a): cor literal em src/design/ui. Use um token — var(--jos-cor-*) ou os exports de tokens/.'
+        },
+        {
+          // Medida arbitrária em classe Tailwind: `text-[14px]`, `size-[20px]`, `rounded-[5px]`.
+          // A forma com `var(--jos-...)` dentro dos colchetes continua permitida.
+          selector: 'Literal[value=/-\\[[0-9]+(\\.[0-9]+)?(px|rem|em|ms|s)\\]/]',
+          message:
+            'Critério 5 (SPEC-DesignSystem-03a): medida literal em classe. Use um token — var(--jos-texto-*), var(--jos-raio-*), var(--jos-tamanho-*), var(--jos-duracao-*).'
+        }
+      ]
+    }
+  },
+  {
     rules: {
       // A fronteira renderer↔main é tipada: `any` a dissolveria em silêncio.
       '@typescript-eslint/no-explicit-any': 'error',

--- a/office3d.config.json
+++ b/office3d.config.json
@@ -27,14 +27,7 @@
         "skin": "#e8b98f",
         "hair": "#3b2a5e"
       },
-      "toolPatterns": [
-        "Task",
-        "Agent",
-        "TodoWrite",
-        "TodoRead",
-        "exit_plan_mode",
-        "Skill"
-      ]
+      "toolPatterns": ["Task", "Agent", "TodoWrite", "TodoRead", "exit_plan_mode", "Skill"]
     },
     {
       "id": "scout",
@@ -49,12 +42,7 @@
         "skin": "#f1c9a5",
         "hair": "#6e3d12"
       },
-      "toolPatterns": [
-        "Read",
-        "Grep",
-        "Glob",
-        "LS"
-      ]
+      "toolPatterns": ["Read", "Grep", "Glob", "LS"]
     },
     {
       "id": "runner",
@@ -69,12 +57,7 @@
         "skin": "#c98a5e",
         "hair": "#2b1410"
       },
-      "toolPatterns": [
-        "Bash",
-        "Computer",
-        "WebSearch",
-        "WebFetch"
-      ]
+      "toolPatterns": ["Bash", "Computer", "WebSearch", "WebFetch"]
     },
     {
       "id": "dev",
@@ -89,12 +72,7 @@
         "skin": "#e8b98f",
         "hair": "#10331c"
       },
-      "toolPatterns": [
-        "Edit",
-        "Write",
-        "MultiEdit",
-        "NotebookEdit"
-      ]
+      "toolPatterns": ["Edit", "Write", "MultiEdit", "NotebookEdit"]
     },
     {
       "id": "byte",
@@ -157,10 +135,7 @@
         "skin": "#e8b98f",
         "hair": "#57606a"
       },
-      "toolPatterns": [
-        "mcp__github__*",
-        "mcp__*github*"
-      ]
+      "toolPatterns": ["mcp__github__*", "mcp__*github*"]
     }
   ],
   "_mcpAgentsExamples": [
@@ -177,9 +152,7 @@
         "skin": "#c98a5e",
         "hair": "#2b2b2b"
       },
-      "toolPatterns": [
-        "mcp__supabase__*"
-      ]
+      "toolPatterns": ["mcp__supabase__*"]
     },
     {
       "id": "postgres",
@@ -194,10 +167,7 @@
         "skin": "#e8b98f",
         "hair": "#1f3d57"
       },
-      "toolPatterns": [
-        "mcp__postgres__*",
-        "mcp__*sql*"
-      ]
+      "toolPatterns": ["mcp__postgres__*", "mcp__*sql*"]
     },
     {
       "id": "figma",
@@ -212,9 +182,7 @@
         "skin": "#f1c9a5",
         "hair": "#3b1a0e"
       },
-      "toolPatterns": [
-        "mcp__figma__*"
-      ]
+      "toolPatterns": ["mcp__figma__*"]
     }
   ],
   "_fallbackAgentId": "(§9.1) Agente que recebe tools sem mapeamento. Nada e descartado; o backend loga `[agents] tool sem mapeamento: <nome>` para voce criar o mapeamento depois.",

--- a/office3d.config.json
+++ b/office3d.config.json
@@ -1,0 +1,227 @@
+{
+  "_comment": "Coloque na raiz do projeto que você desenvolve com Claude Code. Os campos visuais (badge/ui/glow/col/isBoss) alimentam o War Room (SPEC v3 §1.4).",
+  "_version": "3.0.0",
+  "backendUrl": "http://localhost:3001",
+  "demo": {
+    "provider": "auto",
+    "model": null
+  },
+  "_command": "EXPERIMENTAL (§7.3): com enableCommand=true, o botão 'Acionar war room' dispara `claude -p <prompt>` no projeto em cwd. Esse projeto precisa ter o hook instalado (office3d install) para a sala reagir. Default DESLIGADO.",
+  "command": {
+    "enableCommand": false,
+    "cwd": null,
+    "prompt": "rode os testes e reporte o resultado"
+  },
+  "agents": [
+    {
+      "id": "claude",
+      "name": "Claude",
+      "role": "Comando / Incident Lead",
+      "isBoss": true,
+      "badge": "CEO",
+      "ui": "#c08bff",
+      "glow": "rgba(168,85,247,.7)",
+      "col": {
+        "shirt": "#a855f7",
+        "pants": "#241a3a",
+        "skin": "#e8b98f",
+        "hair": "#3b2a5e"
+      },
+      "toolPatterns": [
+        "Task",
+        "Agent",
+        "TodoWrite",
+        "TodoRead",
+        "exit_plan_mode",
+        "Skill"
+      ]
+    },
+    {
+      "id": "scout",
+      "name": "Scout",
+      "role": "Threat Intel",
+      "badge": "SCT",
+      "ui": "#f5a524",
+      "glow": "rgba(245,165,36,.6)",
+      "col": {
+        "shirt": "#f5a524",
+        "pants": "#2a2f45",
+        "skin": "#f1c9a5",
+        "hair": "#6e3d12"
+      },
+      "toolPatterns": [
+        "Read",
+        "Grep",
+        "Glob",
+        "LS"
+      ]
+    },
+    {
+      "id": "runner",
+      "name": "Runner",
+      "role": "Contenção",
+      "badge": "RUN",
+      "ui": "#ff5a4a",
+      "glow": "rgba(239,68,68,.6)",
+      "col": {
+        "shirt": "#ef4444",
+        "pants": "#2a2f45",
+        "skin": "#c98a5e",
+        "hair": "#2b1410"
+      },
+      "toolPatterns": [
+        "Bash",
+        "Computer",
+        "WebSearch",
+        "WebFetch"
+      ]
+    },
+    {
+      "id": "dev",
+      "name": "Dev",
+      "role": "Mitigação / Patch",
+      "badge": "DEV",
+      "ui": "#2bd46e",
+      "glow": "rgba(34,197,94,.6)",
+      "col": {
+        "shirt": "#22c55e",
+        "pants": "#2a2f45",
+        "skin": "#e8b98f",
+        "hair": "#10331c"
+      },
+      "toolPatterns": [
+        "Edit",
+        "Write",
+        "MultiEdit",
+        "NotebookEdit"
+      ]
+    },
+    {
+      "id": "byte",
+      "name": "Byte",
+      "role": "Telemetria",
+      "badge": "BYT",
+      "ui": "#22d3ee",
+      "glow": "rgba(6,182,212,.6)",
+      "col": {
+        "shirt": "#06b6d4",
+        "pants": "#2a2f45",
+        "skin": "#f1c9a5",
+        "hair": "#0a3a44"
+      },
+      "toolPatterns": []
+    },
+    {
+      "id": "finn",
+      "name": "Finn",
+      "role": "Comms / Briefing",
+      "badge": "FNN",
+      "ui": "#eab308",
+      "glow": "rgba(234,179,8,.6)",
+      "col": {
+        "shirt": "#eab308",
+        "pants": "#2a2f45",
+        "skin": "#c98a5e",
+        "hair": "#3b2e08"
+      },
+      "toolPatterns": []
+    },
+    {
+      "id": "aurora",
+      "name": "Aurora",
+      "role": "Verificação / QA",
+      "badge": "AUR",
+      "ui": "#8a8dff",
+      "glow": "rgba(99,102,241,.6)",
+      "col": {
+        "shirt": "#6366f1",
+        "pants": "#2a2f45",
+        "skin": "#e8b98f",
+        "hair": "#1e2150"
+      },
+      "toolPatterns": []
+    }
+  ],
+  "_mcpAgents": "(§9.1) Especialistas de MCP: bonecos que nascem no holo na PRIMEIRA tool do seu servidor e ficam ate o fim da sessao. toolPatterns aceita glob simples (*). Exemplos prontos em _mcpAgentsExamples — copie para mcpAgents para ativar.",
+  "mcpAgents": [
+    {
+      "id": "git",
+      "name": "Git",
+      "role": "GitHub Ops",
+      "badge": "⑂",
+      "ui": "#8250df",
+      "glow": "rgba(130,80,223,.6)",
+      "col": {
+        "shirt": "#24292f",
+        "pants": "#2a2f45",
+        "skin": "#e8b98f",
+        "hair": "#57606a"
+      },
+      "toolPatterns": [
+        "mcp__github__*",
+        "mcp__*github*"
+      ]
+    }
+  ],
+  "_mcpAgentsExamples": [
+    {
+      "id": "supabase",
+      "name": "Supa",
+      "role": "Database Ops",
+      "badge": "⚡",
+      "ui": "#3ecf8e",
+      "glow": "rgba(62,207,142,.6)",
+      "col": {
+        "shirt": "#1c1c1c",
+        "pants": "#2a2f45",
+        "skin": "#c98a5e",
+        "hair": "#2b2b2b"
+      },
+      "toolPatterns": [
+        "mcp__supabase__*"
+      ]
+    },
+    {
+      "id": "postgres",
+      "name": "Postgres",
+      "role": "SQL",
+      "badge": "🐘",
+      "ui": "#336791",
+      "glow": "rgba(51,103,145,.6)",
+      "col": {
+        "shirt": "#336791",
+        "pants": "#2a2f45",
+        "skin": "#e8b98f",
+        "hair": "#1f3d57"
+      },
+      "toolPatterns": [
+        "mcp__postgres__*",
+        "mcp__*sql*"
+      ]
+    },
+    {
+      "id": "figma",
+      "name": "Figma",
+      "role": "Design",
+      "badge": "◈",
+      "ui": "#f24e1e",
+      "glow": "rgba(242,78,30,.6)",
+      "col": {
+        "shirt": "#f24e1e",
+        "pants": "#2a2f45",
+        "skin": "#f1c9a5",
+        "hair": "#3b1a0e"
+      },
+      "toolPatterns": [
+        "mcp__figma__*"
+      ]
+    }
+  ],
+  "_fallbackAgentId": "(§9.1) Agente que recebe tools sem mapeamento. Nada e descartado; o backend loga `[agents] tool sem mapeamento: <nome>` para voce criar o mapeamento depois.",
+  "fallbackAgentId": "claude",
+  "ui": {
+    "showToolInput": true,
+    "maxMessageLength": 120,
+    "walkDurationMs": 1200
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,11 @@
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
+        "@radix-ui/react-checkbox": "^1.3.9",
+        "@radix-ui/react-label": "^2.1.13",
+        "@radix-ui/react-radio-group": "^1.4.5",
+        "@radix-ui/react-select": "^2.3.5",
+        "@radix-ui/react-slider": "^1.4.5",
         "@radix-ui/react-switch": "^1.3.5",
         "@supabase/supabase-js": "^2.110.8",
         "better-sqlite3": "^13.0.1",
@@ -1310,6 +1315,44 @@
         }
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1478,11 +1521,95 @@
         "node": ">=18"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+      "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
       "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.13.tgz",
+      "integrity": "sha512-0Q310knIY0K+mkmncU9FxLggfW7V49Ok2oY+iu27KkERTsQXxYCIC8XW5QoK4w7Jp1z00vT5xj3oxTcn7QlcTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.8"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.9.tgz",
+      "integrity": "sha512-YPXZlqjrKVqKtVD2F828CApHwu+PEu30i7x0Y9gg6SbQ3fJbcaQlDkGPT0gW6HjxoCjAEt8uJ494F1S61KpIjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-context": "1.2.1",
+        "@radix-ui/react-presence": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-use-controllable-state": "1.2.5",
+        "@radix-ui/react-use-size": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.13.tgz",
+      "integrity": "sha512-Q8xYqNRFObXPmi45bFSkGdM2JA5hjBeYGFqzg6lZR3wp6b+cciraVq8DdneTabtws+uOYqjmsvmKOufk/M9Cyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-context": "1.2.1",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-slot": "1.3.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.4",
@@ -1514,6 +1641,208 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.3.tgz",
+      "integrity": "sha512-OdgAA/xb6WOQMKNn0mtbYoruMG6YMaBOnq+evWxSpMmiEMBdeFZawnIWRfPPeVXCRm+0lnN8jpJLjhD7/UIxWw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.17.tgz",
+      "integrity": "sha512-QAXwa38pG0xNAYh1pjdSaf86NrkqsMoDNmget/Y7X8O8E/C3Iqlj9GAPE4DfX9BPLXc7WH2TWSzMRnIoCdcjzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-use-callback-ref": "1.1.3",
+        "@radix-ui/react-use-effect-event": "0.0.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.5.tgz",
+      "integrity": "sha512-UQvlB7L/BYh3P8MLvwZnQkH521EDos40Rwnbt5+Qpg4Vbk0z3xJjRUmR6+aka4aT1IQQXFdO5bNPoE7cvFl5xQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.14.tgz",
+      "integrity": "sha512-/x4htnJfmW53MplkrePaDpf1o/rN1C++g88WpVobULXbSyC19NtLkXmewuJ/HCaceSmfKDNL5gOXcBGnuAvnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-use-callback-ref": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.3.tgz",
+      "integrity": "sha512-f/Wxm0ctyMymUJK0fqTSQlm85rbzdAkoNbPXJQ5+6caowVO8Yx+NWGjGz/oGhs/D+WIbbQpOrU0hU2Li2/42xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.13.tgz",
+      "integrity": "sha512-kj7BXyM4uG0dyeoEdVmPQAOFN291+iJOtiGTvkXe1ijJWLQbAHpFNkopvqquaMVn+zjqTZRhnefESAinMErHKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.8"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.5.tgz",
+      "integrity": "sha512-6hLng2Rs45IZcvZ31BNvMeaFEMMEbtsog4xPcb8LZrGfyoV9fdAXqB9UKhLpTHtL0+E2DhSr6VW54Tehd6ksAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.13",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-context": "1.2.1",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-use-callback-ref": "1.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.3",
+        "@radix-ui/react-use-rect": "1.1.3",
+        "@radix-ui/react-use-size": "1.1.3",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.15.tgz",
+      "integrity": "sha512-kAfBVJUKNNKZuyGQXXG6rKolAV2KAmxxVkPXJgoq9dEFTl39286RufHQFNTL8rzha4vP8159BJ6hMGpB+bqv7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.9.tgz",
+      "integrity": "sha512-LTi1v05bprIb8/GSY/GWusI0jfsYjQ3CD3Nin8o7jVxnpHzVQfzjOQJoJTQkE9bdmOnsS7SFdhkXiBv8PrYnxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.8.tgz",
@@ -1521,6 +1850,147 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.3.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.5.tgz",
+      "integrity": "sha512-BM1xQgw1gpgPSw05U4hJCMDX9GmAS6b6vKZANuNQZo0vf/ah7NZDAnjLd4tPg3z2vMvlI0CV+B2CFM9Z19oQDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-context": "1.2.1",
+        "@radix-ui/react-direction": "1.1.3",
+        "@radix-ui/react-presence": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-roving-focus": "1.1.17",
+        "@radix-ui/react-use-controllable-state": "1.2.5",
+        "@radix-ui/react-use-size": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.17.tgz",
+      "integrity": "sha512-YdJmjETw7Py+4Nziv71jgZ6fH7xQgB5p+pQ5rV8Iufyrm0RHSijec/UV1zPfQoK/YcfzB9nOl/2bi1zf1SjRMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.13",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-context": "1.2.1",
+        "@radix-ui/react-direction": "1.1.3",
+        "@radix-ui/react-id": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-use-callback-ref": "1.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.5",
+        "@radix-ui/react-use-is-hydrated": "0.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.5.tgz",
+      "integrity": "sha512-6CQx0xtdarAkSCsqgLJaz+coYQaru7rt8K6gMItR2rA+WP8/Ig6kRAzP6Zw88RccG98IZnszqJlJx9hejYOL3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.13",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-context": "1.2.1",
+        "@radix-ui/react-direction": "1.1.3",
+        "@radix-ui/react-dismissable-layer": "1.1.17",
+        "@radix-ui/react-focus-guards": "1.1.5",
+        "@radix-ui/react-focus-scope": "1.1.14",
+        "@radix-ui/react-id": "1.1.3",
+        "@radix-ui/react-popper": "1.3.5",
+        "@radix-ui/react-portal": "1.1.15",
+        "@radix-ui/react-presence": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-slot": "1.3.1",
+        "@radix-ui/react-use-callback-ref": "1.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.5",
+        "@radix-ui/react-use-layout-effect": "1.1.3",
+        "@radix-ui/react-use-previous": "1.1.3",
+        "@radix-ui/react-visually-hidden": "1.2.9",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.5.tgz",
+      "integrity": "sha512-7E8C13SdQKQxYganILiVZGEwM0NSbfbFcnNJ93kP++wD2pMT1SMsG3c04PFUlbPpaSXgicYgPeBndgJTvV3NKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.13",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-context": "1.2.1",
+        "@radix-ui/react-direction": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-use-controllable-state": "1.2.5",
+        "@radix-ui/react-use-layout-effect": "1.1.3",
+        "@radix-ui/react-use-previous": "1.1.3",
+        "@radix-ui/react-use-size": "1.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1584,6 +2054,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.3.tgz",
+      "integrity": "sha512-AUS7HoBBAncIsGMLNG+CcpLuJ+JIBbZzmyM8Qdb1eIThX0AlhSSC6wn40xfBlPE+ypx/vSSiRWnklUAjy3U3UA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-controllable-state": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.5.tgz",
@@ -1622,11 +2107,59 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.2.tgz",
+      "integrity": "sha512-2+gAVu9uaSLbopCTvvuWX9MIgEOlyqXC1Ok+KLCO7cZPSHLENs7dL0KbFQUGFIcFKmDW/bmaQRJtd8E3cnMRUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.3.tgz",
       "integrity": "sha512-rDiah9wvtqihWtWz02XreeRKIxt2EJF8y5D9rtY9l5A2zxePAtcPiOMpDugNRw5bFHz+1/8viVoc7ZVKiJknCw==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.3.tgz",
+      "integrity": "sha512-kbefNKla5AGhgvMqrg/qS7mYVLXTEHQLqoFIS03nKN2dAfQQ5PK5Tp+2LxS7BV6a6l4HHv4jTg6rtV2Uajwe2w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.3.tgz",
+      "integrity": "sha512-W0GSYZFKEfi6raMiMEfJSngvVbFDIyxtW5JuVg5NoQBY59l0dVQVGLbhog/tOdwq0qtZ+TXuX1ikSNan4/IZXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1654,6 +2187,35 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.9.tgz",
+      "integrity": "sha512-seuZXNZVCz1kLSQMRO/TdNOSahBI3S5nXE4jzO7u7aFRWQlMAnwyrr8vKMkEU115fCLEyzR2YyjnP+aRMxK34w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.8"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
@@ -3208,6 +3770,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -3642,6 +4216,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -4201,6 +4781,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/glob-parent": {
@@ -5691,6 +6280,75 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
@@ -6265,6 +6923,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.3.9",
+    "@radix-ui/react-label": "^2.1.13",
+    "@radix-ui/react-radio-group": "^1.4.5",
+    "@radix-ui/react-select": "^2.3.5",
+    "@radix-ui/react-slider": "^1.4.5",
     "@radix-ui/react-switch": "^1.3.5",
     "@supabase/supabase-js": "^2.110.8",
     "better-sqlite3": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "postinstall": "electron-rebuild -f -w better-sqlite3",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:prova": "playwright test --config playwright.prova.config.ts",
     "test:report": "node scripts/test-report.mjs",
     "test:report:check": "node scripts/test-report.mjs --check",
     "test:report:selfcheck": "node scripts/test-report.mjs --selfcheck"

--- a/playwright.prova.config.ts
+++ b/playwright.prova.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Prova visual dos controles (SPEC-DesignSystem-03a).
+ *
+ * Config **separado** do `playwright.config.ts`, que sobe o app Electron. Os dois têm nada em
+ * comum além do runner: aquele prova preload/IPC/janela no binário empacotado; este abre uma
+ * galeria estática no Chromium para medir o que só existe com layout — altura real, contraste
+ * computado, fontes carregadas, anel de foco.
+ *
+ * Um config único precisaria alternar `_electron` e browser por projeto, e o `webServer`
+ * subiria mesmo nas execuções que não o usam. Separar é mais barato de ler e de rodar.
+ */
+export default defineConfig({
+  testDir: './tests/prova',
+  testMatch: /.*\.prova\.ts/,
+  timeout: 30_000,
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL: 'http://127.0.0.1:5181',
+    // A galeria é densa; 1280×900 mostra as quatro seções sem rolagem forçada na captura.
+    viewport: { width: 1280, height: 900 }
+  },
+  webServer: {
+    command: 'npx vite --config vite.prova.config.ts',
+    url: 'http://127.0.0.1:5181',
+    // `strictPort` no Vite: se a 5181 estiver ocupada ele falha, em vez de servir outra coisa
+    // e a captura registrar a tela de outro processo.
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000
+  },
+  reporter: [['list']]
+})

--- a/reports/TESTS.md
+++ b/reports/TESTS.md
@@ -12,9 +12,9 @@ Totais da última execução (regenerado, não acumulado):
 
 | Data | Issue | SPEC | Categoria | Testes | Pass | Falha | Cobertura % | PR | Link PR |
 |------|-------|------|-----------|-------:|-----:|------:|------------:|----:|--------|
-| — | — | — | Regras de Negócio | 158 | 158 | 0 | 77.9 | — | — |
+| — | — | — | Regras de Negócio | 203 | 203 | 0 | 78.2 | — | — |
 | — | — | — | Banco | 117 | 117 | 0 | 87.5 | — | — |
-| — | — | — | Tela | 55 | 55 | 0 | 91.2 | — | — |
+| — | — | — | Tela | 95 | 94 | 0 | 89.6 | — | — |
 
 ## Histórico por entrega
 
@@ -61,3 +61,6 @@ Append-only — linhas de entregas passadas são imutáveis.
 | 2026-07-23 | #18 | spec-design-system-02-foundations | Regras de Negócio | 158 | 158 | 0 | 77.9 | #40 | [#40](https://github.com/RodReis/rrb-jarvisOS/pull/40) |
 | 2026-07-23 | #18 | spec-design-system-02-foundations | Banco | 117 | 117 | 0 | 87.5 | #40 | [#40](https://github.com/RodReis/rrb-jarvisOS/pull/40) |
 | 2026-07-23 | #18 | spec-design-system-02-foundations | Tela | 55 | 55 | 0 | 91.2 | #40 | [#40](https://github.com/RodReis/rrb-jarvisOS/pull/40) |
+| 2026-07-23 | #19 | spec-design-system-03a-componentes-acoes-forms | Regras de Negócio | 203 | 203 | 0 | 78.2 | #42 | [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42) |
+| 2026-07-23 | #19 | spec-design-system-03a-componentes-acoes-forms | Banco | 117 | 117 | 0 | 87.5 | #42 | [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42) |
+| 2026-07-23 | #19 | spec-design-system-03a-componentes-acoes-forms | Tela | 95 | 94 | 0 | 89.6 | #42 | [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42) |

--- a/src/design/prova/GaleriaDeControles.tsx
+++ b/src/design/prova/GaleriaDeControles.tsx
@@ -1,0 +1,273 @@
+import { useState } from 'react'
+import { Search, User } from 'lucide-react'
+import { ProvedorDeTema } from '../tokens/provider'
+import type { CorAcento } from '../tokens/acento'
+import type { ModoUi, Modulo } from '../tokens/semantic'
+import {
+  Alternador,
+  Button,
+  ButtonGroup,
+  Checkbox,
+  Combobox,
+  Field,
+  IconButton,
+  Input,
+  Link,
+  PasswordInput,
+  RadioGroup,
+  Select,
+  Slider,
+  Textarea
+} from '../ui'
+
+/**
+ * Galeria de prova dos controles (SPEC-DesignSystem-03a).
+ *
+ * Renderiza os dezesseis componentes em **todos os estados** para inspeção visual por
+ * screenshot. Não é catálogo navegável (Storybook está suspenso — MVP-003 §4) nem parte do
+ * app: é o alvo de uma captura por modo, que é como esta fatia verifica o que jsdom não mede
+ * — layout real, contraste computado, alinhamento óptico, foco desenhado.
+ *
+ * O `jos-prova-*` nos data-attributes existe para o Playwright recortar seções isoladas:
+ * screenshot de página inteira esconde defeito de espaçamento em thumbnail.
+ */
+
+const OPCOES = [
+  { valor: 'seo', rotulo: 'SEO' },
+  { valor: 'conteudo', rotulo: 'Conteúdo' },
+  { valor: 'operacoes', rotulo: 'Operações' },
+  { valor: 'intel', rotulo: 'Intel', desabilitada: true }
+] as const
+
+interface GaleriaProps {
+  readonly modo: ModoUi
+  readonly modulo?: Modulo
+  readonly acento?: CorAcento
+}
+
+export function GaleriaDeControles({
+  modo,
+  modulo = 'jarvis',
+  acento
+}: GaleriaProps): React.JSX.Element {
+  return (
+    <ProvedorDeTema
+      uiTheme={modo}
+      modulo={modulo}
+      superficie={modulo}
+      accentJarvis={acento ?? '#FF5C00'}
+      accentNoa={acento ?? '#C4C4C4'}
+    >
+      <div
+        data-testid="galeria"
+        className="min-h-screen bg-[var(--jos-cor-superficie)] p-8 font-[family-name:var(--jos-fonte-corpo)] text-[var(--jos-cor-texto)]"
+      >
+        <div className="mx-auto flex max-w-4xl flex-col gap-10">
+          <Cabecalho modo={modo} modulo={modulo} />
+          <SecaoAcoes />
+          <SecaoCampos />
+          <SecaoEscolha />
+          <SecaoEstados />
+        </div>
+      </div>
+    </ProvedorDeTema>
+  )
+}
+
+function Cabecalho({ modo, modulo }: { modo: ModoUi; modulo: Modulo }): React.JSX.Element {
+  return (
+    <header className="flex items-baseline justify-between border-b border-[rgba(var(--jos-borda-rgb),0.12)] pb-4">
+      <h1 className="font-[family-name:var(--jos-fonte-display)] text-[length:var(--jos-texto-secao)] tracking-[var(--jos-tracking-acao)]">
+        Controles
+      </h1>
+      <p className="font-[family-name:var(--jos-fonte-mono)] text-[length:var(--jos-texto-micro)] uppercase tracking-[var(--jos-tracking-label)] text-[var(--jos-cor-texto-suave)]">
+        {modulo} · {modo}
+      </p>
+    </header>
+  )
+}
+
+function Secao({
+  titulo,
+  id,
+  children
+}: {
+  titulo: string
+  id: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <section data-prova={id} className="flex flex-col gap-4">
+      <h2 className="font-[family-name:var(--jos-fonte-mono)] text-[length:var(--jos-texto-micro)] uppercase tracking-[var(--jos-tracking-label)] text-[var(--jos-cor-texto-suave)]">
+        {titulo}
+      </h2>
+      {children}
+    </section>
+  )
+}
+
+function SecaoAcoes(): React.JSX.Element {
+  return (
+    <Secao titulo="Ações" id="acoes">
+      <div className="flex flex-wrap items-center gap-3">
+        <Button variante="primaria">Executar</Button>
+        <Button variante="secundaria">Cancelar</Button>
+        <Button variante="perigo">Excluir</Button>
+        <Button variante="primaria" carregando>
+          Executar
+        </Button>
+        <Button variante="secundaria" desabilitado>
+          Indisponível
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <IconButton rotulo="Buscar">
+          <Search className="size-[var(--jos-tamanho-icone)]" />
+        </IconButton>
+        <IconButton rotulo="Filtrar" ativo>
+          <User className="size-[var(--jos-tamanho-icone)]" />
+        </IconButton>
+        <IconButton rotulo="Bloqueado" desabilitado>
+          <Search className="size-[var(--jos-tamanho-icone)]" />
+        </IconButton>
+
+        <ButtonGroup rotulo="Ações do registro">
+          <Button>Descartar</Button>
+          <Button variante="primaria">Salvar</Button>
+        </ButtonGroup>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <Link href="#interno">Ver detalhes</Link>
+        <Link href="https://exemplo.com" externo>
+          Documentação
+        </Link>
+      </div>
+    </Secao>
+  )
+}
+
+function SecaoCampos(): React.JSX.Element {
+  const [texto, setTexto] = useState('')
+  const [senha, setSenha] = useState('')
+  const [notas, setNotas] = useState('')
+
+  return (
+    <Secao titulo="Campos" id="campos">
+      <div className="grid grid-cols-2 gap-5">
+        <Field rotulo="Nome do workflow" obrigatorio descricao="Use minúsculas e hífen.">
+          {(campo) => (
+            <Input
+              {...campo}
+              valor={texto}
+              onMudar={setTexto}
+              placeholder="publicacao-seo"
+              icone={<User className="size-[var(--jos-tamanho-icone)]" />}
+            />
+          )}
+        </Field>
+
+        <Field rotulo="Senha">
+          {(campo) => (
+            <PasswordInput {...campo} valor={senha} onMudar={setSenha} placeholder="••••••••" />
+          )}
+        </Field>
+
+        <Field
+          rotulo="Chave do provedor"
+          erro="Chave inválida. Verifique o valor no painel do provedor."
+        >
+          {(campo) => <Input {...campo} valor="sk-erro" onMudar={() => {}} />}
+        </Field>
+
+        <Field rotulo="Campo travado">
+          {(campo) => <Input {...campo} valor="" onMudar={() => {}} desabilitado />}
+        </Field>
+      </div>
+
+      <Field rotulo="Observações" descricao="Contexto para quem revisar a execução.">
+        {(campo) => (
+          <Textarea {...campo} valor={notas} onMudar={setNotas} placeholder="Anotações…" />
+        )}
+      </Field>
+    </Secao>
+  )
+}
+
+function SecaoEscolha(): React.JSX.Element {
+  const [select, setSelect] = useState('seo')
+  const [combo, setCombo] = useState('')
+  const [radio, setRadio] = useState('sequencial')
+  const [limite, setLimite] = useState(40)
+
+  return (
+    <Secao titulo="Escolha" id="escolha">
+      <div className="grid grid-cols-2 gap-5">
+        <Field rotulo="Especialidade">
+          {(campo) => <Select {...campo} valor={select} onMudar={setSelect} opcoes={OPCOES} />}
+        </Field>
+
+        <Field rotulo="Skill">
+          {(campo) => <Combobox {...campo} valor={combo} onMudar={setCombo} opcoes={OPCOES} />}
+        </Field>
+      </div>
+
+      <div className="grid grid-cols-2 gap-5">
+        <div className="flex flex-col gap-3">
+          <RadioGroup
+            rotulo="Tipo de execução"
+            valor={radio}
+            onMudar={setRadio}
+            opcoes={[
+              { valor: 'sequencial', rotulo: 'Sequencial' },
+              { valor: 'paralelo', rotulo: 'Paralelo' },
+              { valor: 'agendado', rotulo: 'Agendado', desabilitada: true }
+            ]}
+          />
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <Checkbox rotulo="Exigir aprovação" marcado onMudar={() => {}} />
+          <Checkbox rotulo="Seleção parcial" marcado="indeterminado" onMudar={() => {}} />
+          <Checkbox rotulo="Bloqueado" marcado={false} onMudar={() => {}} desabilitado />
+
+          <div className="flex items-center gap-3">
+            <Alternador rotulo="Modo autônomo" ligado onMudar={() => {}} />
+            <span className="text-[length:var(--jos-texto-corpo)]">Modo autônomo</span>
+          </div>
+        </div>
+      </div>
+
+      <Field rotulo="Limite diário">
+        {() => (
+          <Slider
+            rotulo="Limite diário"
+            valor={limite}
+            onMudar={setLimite}
+            formatar={(v) => `${v}%`}
+          />
+        )}
+      </Field>
+    </Secao>
+  )
+}
+
+/**
+ * Foco desenhado.
+ *
+ * O anel de foco é o estado que jsdom **não** mede e que mais some numa revisão apressada:
+ * ele só existe visualmente. A seção existe para que a captura o registre.
+ */
+function SecaoEstados(): React.JSX.Element {
+  return (
+    <Secao titulo="Foco (autofocus no primeiro)" id="foco">
+      <div className="flex flex-wrap items-center gap-3">
+        <Button variante="primaria">Com foco via teclado</Button>
+        <Field rotulo="Campo com foco">
+          {(campo) => <Input {...campo} valor="" onMudar={() => {}} placeholder="Tab até aqui" />}
+        </Field>
+      </div>
+    </Secao>
+  )
+}

--- a/src/design/prova/index.html
+++ b/src/design/prova/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Galeria de controles — prova visual do design system</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/src/design/prova/main.tsx
+++ b/src/design/prova/main.tsx
@@ -1,0 +1,30 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { GaleriaDeControles } from './GaleriaDeControles'
+import type { ModoUi, Modulo } from '../tokens/semantic'
+import type { CorAcento } from '../tokens/acento'
+import './prova.css'
+
+/**
+ * Ponto de entrada da galeria de prova (SPEC-DesignSystem-03a).
+ *
+ * Serve só ao Playwright. **Não é rota do app** e não entra no bundle do renderer: é um
+ * `index.html` próprio, servido pelo Vite em porta separada durante a captura.
+ *
+ * Modo, módulo e acento vêm da query string para que uma execução gere todas as combinações
+ * sem recompilar — `?modo=light&modulo=noa&acento=%232CFF05`.
+ */
+
+const params = new URLSearchParams(window.location.search)
+const modo = (params.get('modo') === 'light' ? 'light' : 'dark') satisfies ModoUi
+const modulo = (params.get('modulo') === 'noa' ? 'noa' : 'jarvis') satisfies Modulo
+const acento = params.get('acento') as CorAcento | null
+
+const raiz = document.getElementById('root')
+if (raiz === null) throw new Error('Elemento #root não encontrado.')
+
+createRoot(raiz).render(
+  <StrictMode>
+    <GaleriaDeControles modo={modo} modulo={modulo} acento={acento ?? undefined} />
+  </StrictMode>
+)

--- a/src/design/prova/prova.css
+++ b/src/design/prova/prova.css
@@ -1,0 +1,28 @@
+@import 'tailwindcss';
+
+/*
+ * Estilos da galeria de prova (SPEC-DesignSystem-03a).
+ *
+ * Importa as fontes locais do DS — a captura tem de mostrar a tipografia real, não a fonte de
+ * sistema. É justamente o que uma verificação por screenshot existe para pegar: se o
+ * `@font-face` estivesse quebrado, o teste em jsdom nunca acusaria.
+ */
+
+@import '../tokens/fontes.css';
+
+/*
+ * Fonte de classes explícita.
+ *
+ * O Tailwind v4 descobre as classes varrendo a partir da `root` do Vite, que aqui é
+ * `src/design/prova/`. Os componentes moram em `../ui/` — **fora** dessa raiz —, então nenhuma
+ * classe deles entrava no CSS gerado: a galeria renderizava texto sem estilo nenhum.
+ *
+ * Foi o primeiro defeito que a captura pegou, e exatamente do tipo que só um navegador revela:
+ * os testes em jsdom continuavam verdes, porque consultam papel ARIA e não pintura.
+ */
+@source '../ui';
+@source '../tokens';
+
+body {
+  margin: 0;
+}

--- a/src/design/tokens/acento.ts
+++ b/src/design/tokens/acento.ts
@@ -143,6 +143,39 @@ export function acentoParaLeitura(acento: string, fundo: string): string {
 }
 
 /**
+ * Cor de texto legível **sobre** uma cor de preenchimento.
+ *
+ * Diferente de `acentoParaLeitura`, que ajusta o acento para ser lido *sobre o fundo da tela*:
+ * aqui o acento **é** o fundo (botão primário sólido), e o que se escolhe é o rótulo. Preto ou
+ * branco, o que der mais contraste — não há terceira opção que ajude, e inventar um cinza
+ * intermediário só reduziria a legibilidade.
+ *
+ * Nasceu da correção do colapso da ação primária (`/impeccable critique`, F03a): com fundo
+ * sólido no acento, o rótulo não pode mais herdar a cor de texto da tela.
+ */
+export function contrasteSobre(fundo: string): '#000000' | '#ffffff' {
+  return contraste('#000000', fundo) >= contraste('#ffffff', fundo) ? '#000000' : '#ffffff'
+}
+
+/**
+ * Variante de **leitura** de uma cor semântica.
+ *
+ * As semânticas (`ok/warn/err/info/violet`) são cores de marca do protótipo e não invertem com
+ * o modo (PRD §15) — mas foram desenhadas para fundo escuro. Como **texto no modo claro** todas
+ * as cinco falham a régua de 4.5:1: `err` 2.53:1, `violet` 2.52:1, `warn` 1.99:1, `ok` 1.78:1,
+ * `info` 1.54:1. Medido no `/impeccable critique` da F03a; o PRODUCT.md exige contraste nos
+ * **dois** modos ("o claro é canônico, não uma cortesia").
+ *
+ * A solução é a mesma que o acento já usava: preservar a cor como identidade em borda, glow e
+ * preenchimento, e ajustar **só a luminância** onde ela renderiza texto. O que muda é que agora
+ * as semânticas também passam por isso — antes só o acento passava, e o teste afirmava a cor
+ * literal sem nunca medir o contraste.
+ */
+export function semanticaParaLeitura(cor: string, fundo: string): string {
+  return acentoParaLeitura(cor, fundo)
+}
+
+/**
  * Ajuste pré-calculado para as 8 cores × 2 modos.
  *
  * A paleta é fechada e conhecida (README §2.4), então o resultado é determinístico e cabe numa

--- a/src/design/tokens/base.ts
+++ b/src/design/tokens/base.ts
@@ -122,6 +122,14 @@ export const TEXTO = {
 export const TAMANHO = {
   /** Altura de campo, botão, select — toda a família alinha aqui. */
   controle: '44px',
+  /**
+   * Alvo mínimo de ponteiro — WCAG 2.2 SC 2.5.8, nível **AA**.
+   *
+   * Vale para todo controle que não tenha rótulo clicável ampliando a área. O checkbox e o
+   * radio ficam abaixo disto na caixa desenhada (`marcador`) porque o `<label>` associado faz
+   * parte do alvo; a alça do slider não tem nada adjacente, então usa esta medida.
+   */
+  alvoMinimo: '24px',
   /** Caixa de checkbox e radio. O alvo real é maior: o rótulo também é clicável. */
   marcador: '20px',
   /** Ícone dentro de controle. */

--- a/src/design/tokens/base.ts
+++ b/src/design/tokens/base.ts
@@ -86,6 +86,51 @@ export const PESO = {
 } as const
 
 /**
+ * Escala tipográfica (PRD §9.1; register product: escala fixa em rem, não fluida).
+ *
+ * Razão ~1.15 entre passos — apertada de propósito: uma UI operacional tem muito mais níveis
+ * de texto que uma página de marca, e contraste exagerado vira ruído. Os valores saem do
+ * protótipo (label mono 11px, corpo 14px, título de tela 20–24px).
+ *
+ * Existe porque a Fatia 03a encontrou `text-[14px]` repetido em sete arquivos: tamanho de
+ * fonte digitado à mão é onde a escala se desfaz sem ninguém perceber.
+ */
+export const TEXTO = {
+  /** Label mono, caption, timestamp. */
+  micro: '11px',
+  /** Mensagem de campo, badge. */
+  mini: '12px',
+  /** Rótulo de botão em mono UPPERCASE. */
+  acao: '13px',
+  /** Corpo e controles — o tamanho padrão da UI. */
+  corpo: '14px',
+  /** Texto de destaque dentro de painel. */
+  realce: '16px',
+  /** Título de seção. */
+  secao: '20px',
+  /** Título de tela (Michroma). */
+  tela: '24px'
+} as const
+
+/**
+ * Tamanhos de caixa dos controles.
+ *
+ * `controle` é a altura única de campo e botão (44px): alvo de toque do WCAG 2.2 e a medida do
+ * protótipo. As densidades `comfortable`/`compact` foram cortadas do MVP (decisão do PI na
+ * F02), então isto é uma lista curta de papéis — não uma escala de espaçamento.
+ */
+export const TAMANHO = {
+  /** Altura de campo, botão, select — toda a família alinha aqui. */
+  controle: '44px',
+  /** Caixa de checkbox e radio. O alvo real é maior: o rótulo também é clicável. */
+  marcador: '20px',
+  /** Ícone dentro de controle. */
+  icone: '16px',
+  /** Ícone pequeno (mensagem de campo, indicador). */
+  iconeMini: '14px'
+} as const
+
+/**
  * `letter-spacing` das labels pequenas — README §3: "toda label pequena e caption é Share Tech
  * Mono em UPPERCASE com letter-spacing 1.5–3px".
  */

--- a/src/design/tokens/index.ts
+++ b/src/design/tokens/index.ts
@@ -35,7 +35,9 @@ export {
   PESO,
   RAIO,
   SOMBRA,
-  sombraComGlow
+  sombraComGlow,
+  TAMANHO,
+  TEXTO
 } from './base'
 
 export {

--- a/src/design/tokens/index.ts
+++ b/src/design/tokens/index.ts
@@ -62,9 +62,11 @@ export {
   acentoParaLeitura,
   contraste,
   CONTRASTE_MINIMO,
+  contrasteSobre,
   hexA,
   luminancia,
   PALETA_ACENTO,
+  semanticaParaLeitura,
   tabelaLeitura,
   type CorAcento
 } from './acento'

--- a/src/design/tokens/provider.tsx
+++ b/src/design/tokens/provider.tsx
@@ -1,5 +1,11 @@
 import { createContext, useContext, useMemo } from 'react'
-import { ACENTO_PADRAO, acentoParaLeitura, type CorAcento } from './acento'
+import {
+  ACENTO_PADRAO,
+  acentoParaLeitura,
+  contrasteSobre,
+  semanticaParaLeitura,
+  type CorAcento
+} from './acento'
 import {
   CAMADA,
   CURVA,
@@ -7,6 +13,7 @@ import {
   ESPACAMENTO_LETRA,
   ESPACO,
   FONTE,
+  PESO,
   RAIO,
   SOMBRA,
   TAMANHO,
@@ -95,7 +102,10 @@ export function variaveisDoTema({
     '--jos-cor-texto': p.textPrimary,
     '--jos-cor-texto-secundario': p.textSecondary,
     '--jos-cor-texto-suave': p.textMuted,
-    '--jos-borda-rgb': bordaRgb(modulo, uiTheme),
+    // `modo`, não `uiTheme`: numa superfície de marca com `uiTheme='light'` a borda tem de vir
+    // do escuro, como todo o resto. Passar a preferência crua aqui daria a uma tela de marca a
+    // borda clara sobre fundo escuro — invisível.
+    '--jos-borda-rgb': bordaRgb(modulo, modo),
 
     // Acento do usuário. Duas variáveis, de propósito: a de marca **preserva** o tom escolhido
     // (borda, glow, fill, dot) e a de leitura tem só a luminância ajustada quando o contraste
@@ -103,13 +113,27 @@ export function variaveisDoTema({
     // PI (2026-07-21) é ter as duas.
     '--jos-cor-acento': acento,
     '--jos-cor-acento-leitura': acentoParaLeitura(acento, p.surface),
+    // Rótulo sobre preenchimento sólido no acento (botão primário): calculado contra o próprio
+    // acento, não contra o fundo da tela. Sem isto, o botão primário sólido herdaria a cor de
+    // texto da tela e ficaria ilegível com acento claro.
+    '--jos-cor-acento-contraste': contrasteSobre(acento),
 
-    // Semânticas — não invertem, não são retematizáveis (PRD §15).
+    // Semânticas — a **cor de marca** não inverte nem é retematizável (PRD §15).
     '--jos-cor-ok': STATUS.ok,
     '--jos-cor-warn': STATUS.warn,
     '--jos-cor-err': STATUS.err,
     '--jos-cor-info': STATUS.info,
     '--jos-cor-violet': STATUS.violet,
+
+    // …mas como **texto** elas foram desenhadas para fundo escuro: no claro, as cinco falham
+    // 4.5:1 (`info` chega a 1.54:1). Estas variantes ajustam só a luminância, preservando o
+    // matiz — a mesma solução que o acento já usava. Borda, glow e preenchimento continuam
+    // usando a cor de marca acima; só o texto lê daqui.
+    '--jos-cor-ok-leitura': semanticaParaLeitura(STATUS.ok, p.surface),
+    '--jos-cor-warn-leitura': semanticaParaLeitura(STATUS.warn, p.surface),
+    '--jos-cor-err-leitura': semanticaParaLeitura(STATUS.err, p.surface),
+    '--jos-cor-info-leitura': semanticaParaLeitura(STATUS.info, p.surface),
+    '--jos-cor-violet-leitura': semanticaParaLeitura(STATUS.violet, p.surface),
 
     // Primitivos que não dependem do modo.
     '--jos-raio-rail': RAIO.rail,
@@ -139,11 +163,16 @@ export function variaveisDoTema({
     '--jos-texto-secao': TEXTO.secao,
     '--jos-texto-tela': TEXTO.tela,
     '--jos-tamanho-controle': TAMANHO.controle,
+    '--jos-tamanho-alvo-minimo': TAMANHO.alvoMinimo,
     '--jos-tamanho-marcador': TAMANHO.marcador,
     '--jos-tamanho-icone': TAMANHO.icone,
     '--jos-tamanho-icone-mini': TAMANHO.iconeMini,
     '--jos-tracking-label': ESPACAMENTO_LETRA.label,
     '--jos-tracking-acao': ESPACAMENTO_LETRA.titulo,
+    // O peso participa da hierarquia de ação (F03a): primária e perigo são mais pesadas que
+    // secundária, e peso sobrevive a qualquer acento — cor sozinha não sobrevive.
+    '--jos-peso-medio': PESO.medio,
+    '--jos-peso-forte': PESO.forte,
     '--jos-camada-overlay': String(CAMADA.overlay),
     '--jos-camada-modal': String(CAMADA.modal),
     '--jos-camada-toast': String(CAMADA.toast)

--- a/src/design/tokens/provider.tsx
+++ b/src/design/tokens/provider.tsx
@@ -1,6 +1,17 @@
 import { createContext, useContext, useMemo } from 'react'
 import { ACENTO_PADRAO, acentoParaLeitura, type CorAcento } from './acento'
-import { CAMADA, CURVA, DURACAO, ESPACO, FONTE, RAIO, SOMBRA } from './base'
+import {
+  CAMADA,
+  CURVA,
+  DURACAO,
+  ESPACAMENTO_LETRA,
+  ESPACO,
+  FONTE,
+  RAIO,
+  SOMBRA,
+  TAMANHO,
+  TEXTO
+} from './base'
 import {
   bordaRgb,
   modoEfetivo,
@@ -116,6 +127,23 @@ export function variaveisDoTema({
     '--jos-fonte-display': FONTE.display,
     '--jos-fonte-corpo': FONTE.corpo,
     '--jos-fonte-mono': FONTE.mono,
+
+    // Escala tipográfica e de caixa (Fatia 03a). Como variáveis, e não só como constantes TS,
+    // porque componente e CSS precisam do mesmo valor — e um `text-[14px]` digitado à mão em
+    // sete arquivos é onde a escala se desfaz sem ninguém perceber.
+    '--jos-texto-micro': TEXTO.micro,
+    '--jos-texto-mini': TEXTO.mini,
+    '--jos-texto-acao': TEXTO.acao,
+    '--jos-texto-corpo': TEXTO.corpo,
+    '--jos-texto-realce': TEXTO.realce,
+    '--jos-texto-secao': TEXTO.secao,
+    '--jos-texto-tela': TEXTO.tela,
+    '--jos-tamanho-controle': TAMANHO.controle,
+    '--jos-tamanho-marcador': TAMANHO.marcador,
+    '--jos-tamanho-icone': TAMANHO.icone,
+    '--jos-tamanho-icone-mini': TAMANHO.iconeMini,
+    '--jos-tracking-label': ESPACAMENTO_LETRA.label,
+    '--jos-tracking-acao': ESPACAMENTO_LETRA.titulo,
     '--jos-camada-overlay': String(CAMADA.overlay),
     '--jos-camada-modal': String(CAMADA.modal),
     '--jos-camada-toast': String(CAMADA.toast)

--- a/src/design/tokens/semantic.ts
+++ b/src/design/tokens/semantic.ts
@@ -122,8 +122,22 @@ export function papeis(modulo: Modulo, modo: ModoUi) {
     surfaceRaised: t[CARD_POR_MODULO[modulo]],
     textPrimary: modo === 'dark' ? '#eef1f5' : '#111316',
     textSecondary: modo === 'dark' ? '#9aa3b2' : '#27292d',
-    /** Label mono / caption. */
-    textMuted: modo === 'dark' ? '#6b7382' : '#44464b',
+    /**
+     * Label mono, caption, placeholder.
+     *
+     * No escuro, **`#757d8c` em vez do `#6b7382` do protótipo**. O valor original mede 4.12:1
+     * sobre o fundo do JARVIS e 4.08:1 sobre o do NOA — abaixo da régua de 4.5:1, e este token
+     * não é decorativo: carrega os placeholders de todos os campos, **todas as labels de
+     * formulário** (via `LABEL_MONO`) e o texto de apoio. Como as labels renderizam em
+     * `--jos-texto-micro` com uppercase e tracking, valem como texto pequeno — sem isenção de
+     * texto grande.
+     *
+     * Medido no `/impeccable critique` da F03a. O desvio é o mínimo que atinge a régua
+     * (4.75:1 / 4.70:1): clarear mais afastaria da hierarquia do protótipo sem ganho de
+     * leitura. Fidelidade cede à legibilidade — é o princípio 1 do PRODUCT.md ("clareza antes
+     * de efeito visual") e o PRD §14 exige contraste mínimo nos dois modos.
+     */
+    textMuted: modo === 'dark' ? '#757d8c' : '#44464b',
     /** RGB base da borda — o alfa é aplicado por uso (`borda(...)`). */
     borderRgb: bordaRgb(modulo, modo)
   } as const

--- a/src/design/tokens/semantic.ts
+++ b/src/design/tokens/semantic.ts
@@ -89,9 +89,24 @@ const TEMA: Readonly<Record<ModoUi, MapaTema>> = temaPrototipo
  * como dado bruto (`tokenDeTema`) para as fatias que forem portar telas específicas — inventar
  * papel para 71 tokens seria decidir escopo que não é meu.
  */
+/**
+ * Token de card por módulo.
+ *
+ * **Os índices de `jt*` e `nt*` são independentes** — não são duas numerações paralelas do
+ * mesmo papel. `jt16` é o card do JARVIS (`rgba(24,27,33,.7)`), mas `nt16` é uma cor de
+ * **texto** (`#c8d4ce`); o card do NOA é `nt2` (`rgba(22,27,25,.7)`).
+ *
+ * Derivar o nome por interpolação (`${prefixo}16`) parecia elegante e produzia campo com fundo
+ * claro sobre página escura no NOA — texto ilegível, e nenhum teste de papel acusaria. O mapa
+ * explícito é feio de propósito: ele obriga a conferir o token no dado em vez de supor.
+ */
+const CARD_POR_MODULO: Readonly<Record<Modulo, string>> = {
+  jarvis: 'jt16',
+  noa: 'nt2'
+}
+
 export function papeis(modulo: Modulo, modo: ModoUi) {
   const t = TEMA[modo]
-  const p = modulo === 'jarvis' ? 'jt' : 'nt'
 
   return {
     /** Fundo do app — README §2.6, linha "fundo app". */
@@ -103,8 +118,8 @@ export function papeis(modulo: Modulo, modo: ModoUi) {
         : modo === 'dark'
           ? '#0b0d0d'
           : '#f2f4f2',
-    /** Card — `jt16`/`nt` correspondente. */
-    surfaceRaised: t[`${p}16`] ?? t[`${p}0`],
+    /** Card — o token de cada módulo, do mapa explícito acima. */
+    surfaceRaised: t[CARD_POR_MODULO[modulo]],
     textPrimary: modo === 'dark' ? '#eef1f5' : '#111316',
     textSecondary: modo === 'dark' ? '#9aa3b2' : '#27292d',
     /** Label mono / caption. */

--- a/src/design/tokens/tokens.spec.ts
+++ b/src/design/tokens/tokens.spec.ts
@@ -17,9 +17,11 @@ import {
   CONTRASTE_MINIMO,
   hexA,
   PALETA_ACENTO,
+  contrasteSobre,
   papeis,
   PREFIXO_TOKEN,
   RISCO,
+  semanticaParaLeitura,
   sombraComGlow,
   STATUS,
   tokenCss,
@@ -133,6 +135,77 @@ describe('papéis por módulo e modo (critério 3)', () => {
     it.each(['jarvis', 'noa'] as const)('no claro, a superfície de %s é clara', (modulo) => {
       const cor = hexParaRgb(papeis(modulo, 'light').surfaceRaised)
       expect(luminanciaAproximada(cor)).toBeGreaterThan(0.7)
+    })
+  })
+})
+
+/**
+ * Contraste de **todos** os papéis de texto (PRD §14; PRODUCT.md § Acessibilidade).
+ *
+ * Estes testes nasceram do `/impeccable critique` da F03a, que mediu o que a suíte não media:
+ * a régua de 4.5:1 era exercitada só no caminho do **acento**, e os papéis embutidos passavam
+ * livres. Achados reais:
+ *
+ * - `textMuted` no escuro: 4.12:1 (jarvis) e 4.08:1 (noa) — e ele carrega placeholders, **todas
+ *   as labels de formulário** e o texto de apoio.
+ * - As cinco semânticas como texto no claro: `err` 2.53:1, `violet` 2.52:1, `warn` 1.99:1,
+ *   `ok` 1.78:1, `info` 1.54:1.
+ *
+ * A lição é sobre método, não sobre cor: o rigor aplicado à cor que o **usuário** escolhe não
+ * tinha sido estendido à cor que **nós** escolhemos.
+ */
+describe('contraste dos papéis de texto (PRD §14)', () => {
+  const MODULOS = ['jarvis', 'noa'] as const
+  const MODOS = ['dark', 'light'] as const
+
+  for (const modulo of MODULOS) {
+    for (const modo of MODOS) {
+      const p = papeis(modulo, modo)
+
+      it(`textPrimary atinge 4.5:1 — ${modulo}/${modo}`, () => {
+        expect(contraste(p.textPrimary, p.surface)).toBeGreaterThanOrEqual(CONTRASTE_MINIMO)
+      })
+
+      it(`textSecondary atinge 4.5:1 — ${modulo}/${modo}`, () => {
+        expect(contraste(p.textSecondary, p.surface)).toBeGreaterThanOrEqual(CONTRASTE_MINIMO)
+      })
+
+      it(`textMuted atinge 4.5:1 — ${modulo}/${modo}`, () => {
+        // Não é texto decorativo: são os placeholders e todas as labels, em `--jos-texto-micro`
+        // com uppercase — texto pequeno, sem isenção de texto grande.
+        expect(contraste(p.textMuted, p.surface)).toBeGreaterThanOrEqual(CONTRASTE_MINIMO)
+      })
+    }
+  }
+
+  describe('semânticas como texto', () => {
+    for (const modulo of MODULOS) {
+      for (const modo of MODOS) {
+        const fundo = papeis(modulo, modo).surface
+
+        it.each(Object.entries(STATUS))(
+          `%s tem variante de leitura legível — ${modulo}/${modo}`,
+          (_nome, cor) => {
+            const leitura = semanticaParaLeitura(cor, fundo)
+            expect(contraste(leitura, fundo)).toBeGreaterThanOrEqual(CONTRASTE_MINIMO)
+          }
+        )
+      }
+    }
+
+    it('a cor de marca é preservada — só a leitura muda', () => {
+      // A identidade da semântica não pode ser reescrita: borda, ícone e preenchimento seguem
+      // usando `STATUS.err`. O ajuste vale só onde ela vira texto.
+      expect(STATUS.err).toBe('#ff6b81')
+    })
+  })
+
+  describe('rótulo sobre preenchimento sólido no acento', () => {
+    it.each(PALETA_ACENTO)('%s recebe rótulo legível', (acento) => {
+      // O botão primário passou a ser sólido no acento (correção do colapso primária/desabilitado).
+      // Com fundo sólido, o rótulo não pode herdar a cor de texto da tela.
+      const rotulo = contrasteSobre(acento)
+      expect(contraste(rotulo, acento)).toBeGreaterThanOrEqual(CONTRASTE_MINIMO)
     })
   })
 })

--- a/src/design/tokens/tokens.spec.ts
+++ b/src/design/tokens/tokens.spec.ts
@@ -100,6 +100,41 @@ describe('papéis por módulo e modo (critério 3)', () => {
     expect(papeis('jarvis', 'dark').textPrimary).toBe('#eef1f5')
     expect(papeis('jarvis', 'light').textPrimary).toBe('#111316')
   })
+
+  describe('a superfície elevada acompanha o modo, nos dois módulos', () => {
+    /**
+     * Este teste nasceu de um defeito real, achado só pelo screenshot da F03a: `surfaceRaised`
+     * derivava o token por interpolação (`${prefixo}16`), presumindo que `nt16` fosse o card do
+     * NOA como `jt16` é o do JARVIS. Mas os índices são independentes — `nt16` é cor de
+     * **texto**, e o campo do NOA escuro ficava com fundo claro, ilegível.
+     *
+     * A asserção é sobre a **luminância**, não sobre o valor: fixar `rgba(22,27,25,.7)` travaria
+     * a cor exata e não pegaria a próxima troca de token errada. O que não pode acontecer é
+     * superfície clara no escuro.
+     */
+    const luminanciaAproximada = (cor: string): number => {
+      const canais = cor.match(/\d+(\.\d+)?/g)
+      if (canais === null) throw new Error(`Cor não interpretável: ${cor}`)
+      const [r, g, b] = canais.slice(0, 3).map(Number)
+      return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
+    }
+
+    const hexParaRgb = (valor: string): string => {
+      if (!valor.startsWith('#')) return valor
+      const n = Number.parseInt(valor.slice(1), 16)
+      return `rgb(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255})`
+    }
+
+    it.each(['jarvis', 'noa'] as const)('no escuro, a superfície de %s é escura', (modulo) => {
+      const cor = hexParaRgb(papeis(modulo, 'dark').surfaceRaised)
+      expect(luminanciaAproximada(cor)).toBeLessThan(0.3)
+    })
+
+    it.each(['jarvis', 'noa'] as const)('no claro, a superfície de %s é clara', (modulo) => {
+      const cor = hexParaRgb(papeis(modulo, 'light').surfaceRaised)
+      expect(luminanciaAproximada(cor)).toBeGreaterThan(0.7)
+    })
+  })
 })
 
 describe('semânticas não são retematizáveis (critério 3; PRD §15)', () => {

--- a/src/design/ui/Alternador.tsx
+++ b/src/design/ui/Alternador.tsx
@@ -36,7 +36,7 @@ export function Alternador({
       disabled={desabilitado}
       className={cx(
         'inline-flex h-6 w-11 shrink-0 items-center rounded-full border p-0.5',
-        'border-[rgba(var(--jos-borda-rgb),0.24)] bg-[var(--jos-cor-superficie)]',
+        'border-[rgba(var(--jos-borda-rgb),0.48)] bg-[var(--jos-cor-superficie)]',
         // Ligado: fundo no acento **e** a alça desloca. A posição da alça é o que sobrevive ao
         // alto contraste e ao daltonismo — cor sozinha não comunica estado (critério 2).
         'data-[state=checked]:border-[var(--jos-cor-acento)]',

--- a/src/design/ui/Alternador.tsx
+++ b/src/design/ui/Alternador.tsx
@@ -1,16 +1,17 @@
 import * as RadixSwitch from '@radix-ui/react-switch'
-import { tokenCss } from '../tokens'
+import { cx, DESABILITADO, FOCO, TRANSICAO } from './base'
 
 /**
- * Alternador liga/desliga — primeiro componente da camada `ui` (SPEC-DesignSystem-01).
+ * Alternador liga/desliga (Switch) — nasceu na SPEC-DesignSystem-01 como primeiro componente
+ * da camada `ui`; alinhado ao vocabulário de controles na 03a.
  *
  * Encapsula o `Switch` do Radix: o consumidor importa daqui e **nunca** do
- * `@radix-ui/react-switch` (PRD §24 "Radix exposto"). O motivo não é estético — é que a
- * API do Radix vira contrato público do DS no dia em que um `patterns` a importa direto,
- * e trocar de primitivo passa a exigir tocar em todo consumidor.
+ * `@radix-ui/react-switch` (PRD §24 "Radix exposto"). O motivo não é estético — é que a API do
+ * Radix vira contrato público do DS no dia em que um `patterns` a importa direto, e trocar de
+ * primitivo passa a exigir tocar em todo consumidor.
  *
- * Por isso as props abaixo são uma lista fechada, escrita à mão: `extends
- * RadixSwitch.SwitchProps` reabriria a superfície inteira por herança.
+ * Por isso as props são uma lista fechada, escrita à mão: `extends RadixSwitch.SwitchProps`
+ * reabriria a superfície inteira por herança, e um `{...rest}` faria o mesmo em runtime.
  */
 
 interface AlternadorProps {
@@ -33,11 +34,25 @@ export function Alternador({
       checked={ligado}
       onCheckedChange={onMudar}
       disabled={desabilitado}
-      // Cor por token: o tema troca a variável, o componente não conhece a cor.
-      style={{ backgroundColor: ligado ? tokenCss('cor-acento') : tokenCss('cor-superficie') }}
-      className="inline-flex h-6 w-10 items-center rounded-full border border-current/20 transition disabled:opacity-50"
+      className={cx(
+        'inline-flex h-6 w-11 shrink-0 items-center rounded-full border p-0.5',
+        'border-[rgba(var(--jos-borda-rgb),0.24)] bg-[var(--jos-cor-superficie)]',
+        // Ligado: fundo no acento **e** a alça desloca. A posição da alça é o que sobrevive ao
+        // alto contraste e ao daltonismo — cor sozinha não comunica estado (critério 2).
+        'data-[state=checked]:border-[var(--jos-cor-acento)]',
+        'data-[state=checked]:bg-[color-mix(in_srgb,var(--jos-cor-acento)_40%,transparent)]',
+        FOCO,
+        TRANSICAO,
+        DESABILITADO
+      )}
     >
-      <RadixSwitch.Thumb className="block size-4 translate-x-1 rounded-full bg-current transition data-[state=checked]:translate-x-5" />
+      <RadixSwitch.Thumb
+        className={cx(
+          'block size-4 rounded-full bg-[var(--jos-cor-texto)]',
+          'transition-transform duration-[var(--jos-duracao-rapida)] ease-[var(--jos-curva-padrao)]',
+          'data-[state=checked]:translate-x-5 data-[state=checked]:bg-[var(--jos-cor-acento)]'
+        )}
+      />
     </RadixSwitch.Root>
   )
 }

--- a/src/design/ui/Button.tsx
+++ b/src/design/ui/Button.tsx
@@ -1,0 +1,120 @@
+import { ALTURA_CONTROLE, BORDA, cx, DESABILITADO, FOCO, SUPERFICIE, TRANSICAO } from './base'
+
+/**
+ * Ações (SPEC-DesignSystem-03a, PRD §11.1).
+ *
+ * Três variantes com papéis distintos, não três estilos: `primaria` usa o **acento do
+ * usuário** (a ação que o fluxo espera), `secundaria` usa borda neutra (alternativa legítima),
+ * `perigo` usa `status-error` (destrutiva). A variante destrutiva lê a semântica e **não** o
+ * acento — se o usuário escolhesse acento vermelho, "excluir" e "salvar" ficariam idênticos.
+ */
+
+type VarianteBotao = 'primaria' | 'secundaria' | 'perigo'
+
+interface ButtonProps {
+  readonly children: React.ReactNode
+  readonly variante?: VarianteBotao
+  readonly onClick?: () => void
+  readonly desabilitado?: boolean
+  /**
+   * Estado de carregamento.
+   *
+   * Desabilita o botão **e** anuncia por `aria-busy` — o spinner sozinho não chega a quem usa
+   * leitor de tela, e um botão que só "parece" ocupado aceita o segundo clique.
+   */
+  readonly carregando?: boolean
+  readonly tipo?: 'button' | 'submit'
+  /** Ocupa a largura do container — como o "ACESSAR" do login. */
+  readonly larguraTotal?: boolean
+  /** Ícone à direita do rótulo (a seta do protótipo). Decorativo: nunca leva significado. */
+  readonly iconeFinal?: React.ReactNode
+  /** Ícone à esquerda — logo de provedor, por exemplo. */
+  readonly iconeInicial?: React.ReactNode
+}
+
+const POR_VARIANTE: Readonly<Record<VarianteBotao, string>> = {
+  // Borda e glow no acento; o rótulo lê pela variável **de leitura**, que já vem com o tom
+  // ajustado quando o acento escolhido seria ilegível como texto (F02).
+  primaria: cx(
+    'border-[var(--jos-cor-acento)] text-[var(--jos-cor-acento-leitura)]',
+    'bg-[color-mix(in_srgb,var(--jos-cor-acento)_10%,transparent)]',
+    'hover:bg-[color-mix(in_srgb,var(--jos-cor-acento)_18%,transparent)]',
+    'hover:shadow-[0_0_24px_-12px_var(--jos-cor-acento)]'
+  ),
+  secundaria: cx(
+    BORDA,
+    SUPERFICIE,
+    'text-[var(--jos-cor-texto)]',
+    'hover:border-[rgba(var(--jos-borda-rgb),0.24)]'
+  ),
+  perigo: cx(
+    'border-[var(--jos-cor-err)] text-[var(--jos-cor-err)]',
+    'bg-[color-mix(in_srgb,var(--jos-cor-err)_10%,transparent)]',
+    'hover:bg-[color-mix(in_srgb,var(--jos-cor-err)_18%,transparent)]'
+  )
+}
+
+export function Button({
+  children,
+  variante = 'secundaria',
+  onClick,
+  desabilitado = false,
+  carregando = false,
+  tipo = 'button',
+  larguraTotal = false,
+  iconeFinal,
+  iconeInicial
+}: ButtonProps): React.JSX.Element {
+  return (
+    <button
+      type={tipo}
+      onClick={onClick}
+      disabled={desabilitado || carregando}
+      aria-busy={carregando || undefined}
+      style={{ height: ALTURA_CONTROLE }}
+      className={cx(
+        'inline-flex items-center justify-center gap-2 rounded-[var(--jos-raio-card)] border px-5',
+        // Rótulo em mono UPPERCASE: é a assinatura do botão no protótipo. Diverge do
+        // "sem display font em label" do register product — fidelidade ao protótipo é a regra
+        // da spec, e a escolha está registrada em PRODUCT.md.
+        'font-[family-name:var(--jos-fonte-mono)] text-[13px] uppercase tracking-[2px]',
+        larguraTotal && 'w-full',
+        POR_VARIANTE[variante],
+        FOCO,
+        TRANSICAO,
+        DESABILITADO
+      )}
+    >
+      {carregando ? (
+        <>
+          {/* O texto acompanha o spinner: estado nunca só por forma ou cor (critério 2). */}
+          <Girando />
+          <span>Aguarde</span>
+        </>
+      ) : (
+        <>
+          {iconeInicial}
+          <span>{children}</span>
+          {iconeFinal}
+        </>
+      )}
+    </button>
+  )
+}
+
+/**
+ * Indicador de carregamento.
+ *
+ * `aria-hidden` porque o `aria-busy` do botão já anuncia o estado — anunciar duas vezes faz o
+ * leitor de tela repetir. A animação lê a duração do token, então `prefers-reduced-motion` a
+ * congela junto com o resto (F02).
+ */
+function Girando(): React.JSX.Element {
+  return (
+    <span
+      aria-hidden="true"
+      className="size-3.5 animate-spin rounded-full border border-current border-t-transparent"
+      style={{ animationDuration: 'calc(var(--jos-duracao-lenta) * 1.2)' }}
+    />
+  )
+}

--- a/src/design/ui/Button.tsx
+++ b/src/design/ui/Button.tsx
@@ -32,13 +32,31 @@ interface ButtonProps {
   readonly iconeInicial?: React.ReactNode
 }
 
+/**
+ * Aparência por variante.
+ *
+ * **A hierarquia de ação é preenchimento, não matiz.** A primeira versão distinguia as
+ * variantes só por cor (borda + 10% de fundo no acento), e isso colapsava: com um acento de
+ * baixa croma — `#C4C4C4`, o **default do NOA**, e `#FFFFE3`, ambos na paleta de 8 —, primária,
+ * carregando e desabilitado renderizavam como o mesmo botão cinza-claro. A ação que o fluxo
+ * espera ficava indistinguível da que não pode ser clicada.
+ *
+ * Achado pelo `/impeccable critique` sobre a captura do NOA claro, com os 91 testes de papel
+ * verdes: papel ARIA não mede rank visual.
+ *
+ * A correção aplica, ao nível da **variante**, a mesma regra que os componentes já seguem
+ * internamente (PRD §14 — nunca só por cor): `primaria` é sólida e mais pesada; `perigo` é
+ * contornada e pesada; `secundaria` é contornada e leve. Peso e preenchimento sobrevivem a
+ * qualquer acento, ao alto contraste e ao daltonismo.
+ */
 const POR_VARIANTE: Readonly<Record<VarianteBotao, string>> = {
-  // Borda e glow no acento; o rótulo lê pela variável **de leitura**, que já vem com o tom
-  // ajustado quando o acento escolhido seria ilegível como texto (F02).
+  // Preenchimento sólido: é o que separa a ação primária de todas as outras, independentemente
+  // da cor escolhida. O rótulo lê por `--jos-cor-acento-contraste`, calculado contra o próprio
+  // acento (preto ou branco, o que der contraste) — não contra o fundo da tela.
   primaria: cx(
-    'border-[var(--jos-cor-acento)] text-[var(--jos-cor-acento-leitura)]',
-    'bg-[color-mix(in_srgb,var(--jos-cor-acento)_10%,transparent)]',
-    'hover:bg-[color-mix(in_srgb,var(--jos-cor-acento)_18%,transparent)]',
+    'border-[var(--jos-cor-acento)] bg-[var(--jos-cor-acento)]',
+    'text-[var(--jos-cor-acento-contraste)] font-[var(--jos-peso-forte)]',
+    'hover:brightness-110',
     'hover:shadow-[0_0_24px_-12px_var(--jos-cor-acento)]'
   ),
   secundaria: cx(
@@ -47,8 +65,11 @@ const POR_VARIANTE: Readonly<Record<VarianteBotao, string>> = {
     'text-[var(--jos-cor-texto)]',
     'hover:border-[rgba(var(--jos-borda-rgb),0.24)]'
   ),
+  // Contornada e pesada: distingue-se da secundária pelo peso mesmo antes de a cor ser lida.
+  // Fica contornada, e não sólida, porque ação destrutiva não deve competir em proeminência
+  // com a primária — o usuário não deve ser atraído a excluir.
   perigo: cx(
-    'border-[var(--jos-cor-err)] text-[var(--jos-cor-err)]',
+    'border-[var(--jos-cor-err)] text-[var(--jos-cor-err-leitura)] font-[var(--jos-peso-forte)]',
     'bg-[color-mix(in_srgb,var(--jos-cor-err)_10%,transparent)]',
     'hover:bg-[color-mix(in_srgb,var(--jos-cor-err)_18%,transparent)]'
   )
@@ -85,19 +106,16 @@ export function Button({
         DESABILITADO
       )}
     >
-      {carregando ? (
-        <>
-          {/* O texto acompanha o spinner: estado nunca só por forma ou cor (critério 2). */}
-          <Girando />
-          <span>Aguarde</span>
-        </>
-      ) : (
-        <>
-          {iconeInicial}
-          <span>{children}</span>
-          {iconeFinal}
-        </>
-      )}
+      {/*
+        O rótulo **permanece** enquanto carrega; o spinner entra ao lado dele.
+        A primeira versão trocava o texto por "Aguarde", e num console operacional com várias
+        ações em voo o usuário deixava de saber *qual* estava rodando — além de a largura do
+        botão saltar. `aria-busy` já leva o estado à tecnologia assistiva, então a palavra
+        nunca foi o que informava.
+      */}
+      {carregando ? <Girando /> : iconeInicial}
+      <span>{children}</span>
+      {!carregando && iconeFinal}
     </button>
   )
 }

--- a/src/design/ui/Button.tsx
+++ b/src/design/ui/Button.tsx
@@ -77,7 +77,7 @@ export function Button({
         // Rótulo em mono UPPERCASE: é a assinatura do botão no protótipo. Diverge do
         // "sem display font em label" do register product — fidelidade ao protótipo é a regra
         // da spec, e a escolha está registrada em PRODUCT.md.
-        'font-[family-name:var(--jos-fonte-mono)] text-[13px] uppercase tracking-[2px]',
+        'font-[family-name:var(--jos-fonte-mono)] text-[length:var(--jos-texto-acao)] uppercase tracking-[var(--jos-tracking-acao)]',
         larguraTotal && 'w-full',
         POR_VARIANTE[variante],
         FOCO,

--- a/src/design/ui/ButtonGroup.tsx
+++ b/src/design/ui/ButtonGroup.tsx
@@ -1,37 +1,30 @@
-import { cx } from './base'
-
 /**
  * Agrupamento de ações relacionadas (SPEC-DesignSystem-03a, PRD §11.1).
  *
- * Dois papéis distintos, e é por isso que `papel` existe em vez de o grupo ser só um `div` com
- * `gap`:
+ * Só um papel: `role="group"` para botões independentes lado a lado (Cancelar / Salvar). É
+ * agrupamento visual e semântico, sem estado de seleção.
  *
- * - `acoes` — botões independentes lado a lado (Cancelar / Salvar). Semanticamente é só um
- *   agrupamento visual, então recebe `role="group"`.
- * - `segmentado` — opções **mutuamente exclusivas** (uma vista de cada vez). Isso é um
- *   `radiogroup`, não uma fileira de botões: sem esse papel, o leitor de tela anuncia três
- *   botões soltos e não diz qual está ativo. É a mesma lição registrada na F02 do MVP-001
- *   (os botões de espaço viraram `radiogroup` pelo mesmo motivo).
+ * **Havia uma variante `segmentado`** que aplicava `role="radiogroup"` para opções mutuamente
+ * exclusivas. Foi removida: `radiogroup` exige filhos com `role="radio"` e `aria-checked`, e os
+ * filhos aqui são `<button>` comuns — o leitor de tela anunciaria um grupo de rádio **sem
+ * rádios dentro**, que é pior que a fileira de botões que a variante tentava corrigir. A
+ * promessa estava na assinatura, não na árvore.
+ *
+ * Achado pelo `/impeccable critique` da F03a. Um controle segmentado de verdade precisa de
+ * componente próprio, com estado e teclado (setas navegam, não Tab) — isso é escopo da F04a
+ * (AppShell + navegação), onde há tela que o use. Entregar a casca agora seria oferecer
+ * acessibilidade que não existe.
  */
 
 interface ButtonGroupProps {
   readonly children: React.ReactNode
-  /** Nome acessível do grupo — obrigatório em `segmentado`, recomendado em `acoes`. */
+  /** Nome acessível do grupo — o leitor anuncia "grupo, <rótulo>" ao entrar. */
   readonly rotulo?: string
-  readonly papel?: 'acoes' | 'segmentado'
 }
 
-export function ButtonGroup({
-  children,
-  rotulo,
-  papel = 'acoes'
-}: ButtonGroupProps): React.JSX.Element {
+export function ButtonGroup({ children, rotulo }: ButtonGroupProps): React.JSX.Element {
   return (
-    <div
-      role={papel === 'segmentado' ? 'radiogroup' : 'group'}
-      aria-label={rotulo}
-      className={cx('inline-flex items-center', papel === 'segmentado' ? 'gap-1' : 'gap-3')}
-    >
+    <div role="group" aria-label={rotulo} className="inline-flex items-center gap-3">
       {children}
     </div>
   )

--- a/src/design/ui/ButtonGroup.tsx
+++ b/src/design/ui/ButtonGroup.tsx
@@ -1,0 +1,38 @@
+import { cx } from './base'
+
+/**
+ * Agrupamento de ações relacionadas (SPEC-DesignSystem-03a, PRD §11.1).
+ *
+ * Dois papéis distintos, e é por isso que `papel` existe em vez de o grupo ser só um `div` com
+ * `gap`:
+ *
+ * - `acoes` — botões independentes lado a lado (Cancelar / Salvar). Semanticamente é só um
+ *   agrupamento visual, então recebe `role="group"`.
+ * - `segmentado` — opções **mutuamente exclusivas** (uma vista de cada vez). Isso é um
+ *   `radiogroup`, não uma fileira de botões: sem esse papel, o leitor de tela anuncia três
+ *   botões soltos e não diz qual está ativo. É a mesma lição registrada na F02 do MVP-001
+ *   (os botões de espaço viraram `radiogroup` pelo mesmo motivo).
+ */
+
+interface ButtonGroupProps {
+  readonly children: React.ReactNode
+  /** Nome acessível do grupo — obrigatório em `segmentado`, recomendado em `acoes`. */
+  readonly rotulo?: string
+  readonly papel?: 'acoes' | 'segmentado'
+}
+
+export function ButtonGroup({
+  children,
+  rotulo,
+  papel = 'acoes'
+}: ButtonGroupProps): React.JSX.Element {
+  return (
+    <div
+      role={papel === 'segmentado' ? 'radiogroup' : 'group'}
+      aria-label={rotulo}
+      className={cx('inline-flex items-center', papel === 'segmentado' ? 'gap-1' : 'gap-3')}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/design/ui/Combobox.tsx
+++ b/src/design/ui/Combobox.tsx
@@ -96,8 +96,27 @@ export function Combobox({
 
   const idOpcaoAtiva = aberto && filtradas.length > 0 ? `${base}-opcao-${indiceAtivo}` : undefined
 
+  /**
+   * Fecha quando o foco sai do componente inteiro.
+   *
+   * A primeira versão usava `onBlur` com um `setTimeout(…, 120)` para dar tempo de o
+   * `mousedown` da opção registrar antes de a lista sumir. Três problemas: o timer nunca era
+   * limpo (dispara após o unmount), os 120ms eram calibrados contra o handler em vez de
+   * derivados de algo, e num quadro lento a lista fechava antes do clique — o usuário via um
+   * clique que não fez nada.
+   *
+   * `focusout` com `relatedTarget` responde a pergunta certa — "o foco foi para fora daqui?" —
+   * sem constante de tempo para calibrar e sem timer para vazar.
+   */
+  function aoSairODoFoco(e: React.FocusEvent<HTMLDivElement>): void {
+    const destino = e.relatedTarget
+    if (destino instanceof Node && e.currentTarget.contains(destino)) return
+    setAberto(false)
+    setBusca('')
+  }
+
   return (
-    <div className="relative">
+    <div className="relative" onBlur={aoSairODoFoco}>
       <div className="relative flex items-center">
         <Search
           aria-hidden="true"
@@ -118,7 +137,6 @@ export function Combobox({
             setIndiceAtivo(0)
           }}
           onFocus={abrir}
-          onBlur={() => window.setTimeout(() => setAberto(false), 120)}
           onKeyDown={aoTeclar}
           placeholder={placeholder}
           disabled={desabilitado}

--- a/src/design/ui/Combobox.tsx
+++ b/src/design/ui/Combobox.tsx
@@ -124,7 +124,7 @@ export function Combobox({
           disabled={desabilitado}
           style={{ height: ALTURA_CONTROLE }}
           className={cx(
-            'w-full rounded-[var(--jos-raio-card)] pl-10 pr-10 text-[14px]',
+            'w-full rounded-[var(--jos-raio-card)] pl-10 pr-10 text-[length:var(--jos-texto-corpo)]',
             'font-[family-name:var(--jos-fonte-corpo)] text-[var(--jos-cor-texto)]',
             BORDA,
             SUPERFICIE,
@@ -154,7 +154,7 @@ export function Combobox({
           )}
         >
           {filtradas.length === 0 ? (
-            <li className="px-3 py-2 text-[13px] text-[var(--jos-cor-texto-suave)]">
+            <li className="px-3 py-2 text-[length:var(--jos-texto-acao)] text-[var(--jos-cor-texto-suave)]">
               {semResultado}
             </li>
           ) : (
@@ -176,7 +176,7 @@ export function Combobox({
                   onMouseEnter={() => setIndiceAtivo(i)}
                   className={cx(
                     'flex cursor-default items-center gap-2 rounded-[var(--jos-raio-chip)]',
-                    'py-2 pl-8 pr-3 text-[14px] text-[var(--jos-cor-texto)]',
+                    'py-2 pl-8 pr-3 text-[length:var(--jos-texto-corpo)] text-[var(--jos-cor-texto)]',
                     'relative',
                     i === indiceAtivo &&
                       'bg-[color-mix(in_srgb,var(--jos-cor-acento)_14%,transparent)]',

--- a/src/design/ui/Combobox.tsx
+++ b/src/design/ui/Combobox.tsx
@@ -1,0 +1,196 @@
+import { useId, useMemo, useRef, useState } from 'react'
+import { Check, ChevronDown, Search } from 'lucide-react'
+import type { AtributosDoControle } from './Field'
+import type { OpcaoSelect } from './Select'
+import { ALTURA_CONTROLE, BORDA, cx, DESABILITADO, FOCO, SUPERFICIE, TRANSICAO } from './base'
+
+/**
+ * Seleção com busca (SPEC-DesignSystem-03a, PRD §11.2).
+ *
+ * Construído sobre o padrão ARIA `combobox` diretamente, e não sobre um primitivo Radix: o
+ * Radix não publica um Combobox, e trazer uma segunda biblioteca (Downshift, cmdk) para um
+ * único componente pagaria dependência nova e um segundo vocabulário de composição. O padrão
+ * está implementado por inteiro aqui — `role="combobox"`, `aria-expanded`, `aria-controls`,
+ * `aria-activedescendant`, teclado completo — e o consumidor vê a mesma API do `Select`.
+ *
+ * Teclado (WAI-ARIA APG): ↓/↑ navegam, Enter confirma, Escape fecha sem alterar, Tab sai
+ * confirmando o foco atual. Sem isso o componente é um input com uma lista bonita ao lado.
+ */
+
+interface ComboboxProps extends Partial<AtributosDoControle> {
+  readonly valor: string
+  readonly onMudar: (valor: string) => void
+  readonly opcoes: readonly OpcaoSelect[]
+  readonly placeholder?: string
+  readonly desabilitado?: boolean
+  /** Texto quando a busca não encontra nada — ensina em vez de dizer "vazio". */
+  readonly semResultado?: string
+}
+
+export function Combobox({
+  valor,
+  onMudar,
+  opcoes,
+  placeholder = 'Buscar',
+  desabilitado = false,
+  semResultado = 'Nenhuma opção corresponde à busca',
+  ...campo
+}: ComboboxProps): React.JSX.Element {
+  const base = useId()
+  const idLista = `${base}-lista`
+  const [aberto, setAberto] = useState(false)
+  const [busca, setBusca] = useState('')
+  const [indiceAtivo, setIndiceAtivo] = useState(0)
+  const refEntrada = useRef<HTMLInputElement>(null)
+
+  const filtradas = useMemo(() => {
+    const termo = busca.trim().toLowerCase()
+    if (termo === '') return opcoes
+    return opcoes.filter((o) => o.rotulo.toLowerCase().includes(termo))
+  }, [opcoes, busca])
+
+  const selecionada = opcoes.find((o) => o.valor === valor)
+  // Fechado mostra o rótulo escolhido; aberto mostra o que está sendo digitado. Misturar os
+  // dois é o que faz combobox parecer "apagar o valor sozinho".
+  const textoVisivel = aberto ? busca : (selecionada?.rotulo ?? '')
+
+  function abrir(): void {
+    if (desabilitado) return
+    setAberto(true)
+    setBusca('')
+    setIndiceAtivo(
+      Math.max(
+        0,
+        filtradas.findIndex((o) => o.valor === valor)
+      )
+    )
+  }
+
+  function escolher(opcao: OpcaoSelect): void {
+    if (opcao.desabilitada === true) return
+    onMudar(opcao.valor)
+    setAberto(false)
+    setBusca('')
+    refEntrada.current?.focus()
+  }
+
+  function aoTeclar(e: React.KeyboardEvent<HTMLInputElement>): void {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      if (!aberto) return abrir()
+      setIndiceAtivo((i) => Math.min(i + 1, filtradas.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setIndiceAtivo((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter') {
+      if (!aberto) return
+      e.preventDefault()
+      const alvo = filtradas[indiceAtivo]
+      if (alvo !== undefined) escolher(alvo)
+    } else if (e.key === 'Escape') {
+      // Escape fecha **sem** alterar o valor — cancelar tem de ser sempre reversível.
+      setAberto(false)
+      setBusca('')
+    }
+  }
+
+  const idOpcaoAtiva = aberto && filtradas.length > 0 ? `${base}-opcao-${indiceAtivo}` : undefined
+
+  return (
+    <div className="relative">
+      <div className="relative flex items-center">
+        <Search
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3.5 size-4 text-[var(--jos-cor-texto-suave)]"
+        />
+        <input
+          {...campo}
+          ref={refEntrada}
+          role="combobox"
+          aria-expanded={aberto}
+          aria-controls={idLista}
+          aria-autocomplete="list"
+          aria-activedescendant={idOpcaoAtiva}
+          value={textoVisivel}
+          onChange={(e) => {
+            setBusca(e.target.value)
+            setAberto(true)
+            setIndiceAtivo(0)
+          }}
+          onFocus={abrir}
+          onBlur={() => window.setTimeout(() => setAberto(false), 120)}
+          onKeyDown={aoTeclar}
+          placeholder={placeholder}
+          disabled={desabilitado}
+          style={{ height: ALTURA_CONTROLE }}
+          className={cx(
+            'w-full rounded-[var(--jos-raio-card)] pl-10 pr-10 text-[14px]',
+            'font-[family-name:var(--jos-fonte-corpo)] text-[var(--jos-cor-texto)]',
+            BORDA,
+            SUPERFICIE,
+            'placeholder:text-[var(--jos-cor-texto-suave)]',
+            'aria-[invalid=true]:border-[var(--jos-cor-err)]',
+            FOCO,
+            TRANSICAO,
+            DESABILITADO
+          )}
+        />
+        <ChevronDown
+          aria-hidden="true"
+          className="pointer-events-none absolute right-3.5 size-4 text-[var(--jos-cor-texto-suave)]"
+        />
+      </div>
+
+      {aberto && (
+        <ul
+          id={idLista}
+          role="listbox"
+          className={cx(
+            'absolute left-0 right-0 top-[calc(100%+6px)] z-[var(--jos-camada-overlay)]',
+            'max-h-56 overflow-auto rounded-[var(--jos-raio-card)] p-1',
+            'shadow-[var(--jos-sombra-card)]',
+            BORDA,
+            'bg-[var(--jos-cor-superficie-elevada)]'
+          )}
+        >
+          {filtradas.length === 0 ? (
+            <li className="px-3 py-2 text-[13px] text-[var(--jos-cor-texto-suave)]">
+              {semResultado}
+            </li>
+          ) : (
+            filtradas.map((o, i) => {
+              const escolhida = o.valor === valor
+              return (
+                <li
+                  key={o.valor}
+                  id={`${base}-opcao-${i}`}
+                  role="option"
+                  aria-selected={escolhida}
+                  aria-disabled={o.desabilitada}
+                  onMouseDown={(e) => {
+                    // `mousedown` e não `click`: o `blur` do input dispararia antes do click e
+                    // fecharia a lista, engolindo a escolha.
+                    e.preventDefault()
+                    escolher(o)
+                  }}
+                  onMouseEnter={() => setIndiceAtivo(i)}
+                  className={cx(
+                    'flex cursor-default items-center gap-2 rounded-[var(--jos-raio-chip)]',
+                    'py-2 pl-8 pr-3 text-[14px] text-[var(--jos-cor-texto)]',
+                    'relative',
+                    i === indiceAtivo &&
+                      'bg-[color-mix(in_srgb,var(--jos-cor-acento)_14%,transparent)]',
+                    o.desabilitada === true && 'opacity-45'
+                  )}
+                >
+                  {escolhida && <Check aria-hidden="true" className="absolute left-2 size-4" />}
+                  {o.rotulo}
+                </li>
+              )
+            })
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/design/ui/Controles.tsx
+++ b/src/design/ui/Controles.tsx
@@ -204,8 +204,6 @@ export function Slider({
         max={maximo}
         step={passo}
         disabled={desabilitado}
-        aria-label={rotulo}
-        aria-valuetext={formatar(valor)}
         className={cx(
           'relative flex h-5 w-full flex-1 touch-none select-none items-center',
           desabilitado && 'opacity-45'
@@ -214,7 +212,14 @@ export function Slider({
         <RadixSlider.Track className="relative h-1 w-full grow rounded-full bg-[rgba(var(--jos-borda-rgb),0.16)]">
           <RadixSlider.Range className="absolute h-full rounded-full bg-[var(--jos-cor-acento)]" />
         </RadixSlider.Track>
+        {/*
+          O nome e o valor legível vão na **alça**, não na raiz: quem carrega `role="slider"` é
+          o Thumb, e é nele que o leitor de tela procura `aria-label`/`aria-valuetext`. Pôr no
+          Root deixa a faixa anônima — foi o que os testes pegaram.
+        */}
         <RadixSlider.Thumb
+          aria-label={rotulo}
+          aria-valuetext={formatar(valor)}
           className={cx(
             'block size-4 rounded-full border-2 border-[var(--jos-cor-acento)]',
             'bg-[var(--jos-cor-superficie-elevada)]',

--- a/src/design/ui/Controles.tsx
+++ b/src/design/ui/Controles.tsx
@@ -1,0 +1,236 @@
+import { useId } from 'react'
+import * as RadixCheckbox from '@radix-ui/react-checkbox'
+import * as RadixRadioGroup from '@radix-ui/react-radio-group'
+import * as RadixSlider from '@radix-ui/react-slider'
+import { Check, Minus } from 'lucide-react'
+import type { AtributosDoControle } from './Field'
+import { cx, DESABILITADO, FOCO, LABEL_MONO, SUPERFICIE, TRANSICAO } from './base'
+
+/**
+ * Controles de escolha e faixa (SPEC-DesignSystem-03a, PRD §11.2; critério 3).
+ *
+ * Todos sobre Radix, todos com **superfície pública própria**: o consumidor nunca importa
+ * `@radix-ui/*` nem compõe `Root`/`Item`/`Indicator`. O que ele passa é dado (`opcoes`,
+ * `valor`) e callbacks tipados.
+ *
+ * O alvo de toque respeita WCAG 2.2 (2.5.8): a caixa desenhada tem 18–20px, mas a área
+ * clicável inclui o rótulo, que é o que o `label` envolvente garante.
+ */
+
+const CAIXA = cx(
+  'flex size-[20px] shrink-0 items-center justify-center rounded-[5px] border',
+  'border-[rgba(var(--jos-borda-rgb),0.24)]',
+  SUPERFICIE,
+  // Marcado: fundo no acento **e** o ícone de check. O ícone é o que sobrevive ao alto
+  // contraste e ao daltonismo — cor sozinha não comunica estado (critério 2).
+  'data-[state=checked]:border-[var(--jos-cor-acento)]',
+  'data-[state=checked]:bg-[color-mix(in_srgb,var(--jos-cor-acento)_22%,transparent)]',
+  'data-[state=indeterminate]:border-[var(--jos-cor-acento)]',
+  FOCO,
+  TRANSICAO,
+  DESABILITADO
+)
+
+interface CheckboxProps extends Partial<AtributosDoControle> {
+  readonly rotulo: string
+  readonly marcado: boolean | 'indeterminado'
+  readonly onMudar: (marcado: boolean) => void
+  readonly desabilitado?: boolean
+}
+
+export function Checkbox({
+  rotulo,
+  marcado,
+  onMudar,
+  desabilitado = false,
+  ...campo
+}: CheckboxProps): React.JSX.Element {
+  const id = useId()
+  const estado = marcado === 'indeterminado' ? 'indeterminate' : marcado
+
+  return (
+    <div className="flex items-center gap-2.5">
+      <RadixCheckbox.Root
+        {...campo}
+        id={id}
+        checked={estado}
+        onCheckedChange={(v) => onMudar(v === true)}
+        disabled={desabilitado}
+        className={CAIXA}
+      >
+        <RadixCheckbox.Indicator className="text-[var(--jos-cor-acento-leitura)]">
+          {marcado === 'indeterminado' ? (
+            <Minus aria-hidden="true" className="size-3.5" />
+          ) : (
+            <Check aria-hidden="true" className="size-3.5" />
+          )}
+        </RadixCheckbox.Indicator>
+      </RadixCheckbox.Root>
+      {/* O rótulo é clicável: amplia o alvo muito além dos 20px da caixa. */}
+      <label
+        htmlFor={id}
+        className={cx(
+          'cursor-pointer text-[14px] text-[var(--jos-cor-texto)]',
+          desabilitado && 'cursor-not-allowed opacity-45'
+        )}
+      >
+        {rotulo}
+      </label>
+    </div>
+  )
+}
+
+export interface OpcaoRadio {
+  readonly valor: string
+  readonly rotulo: string
+  readonly desabilitada?: boolean
+}
+
+interface RadioGroupProps extends Partial<AtributosDoControle> {
+  readonly valor: string
+  readonly onMudar: (valor: string) => void
+  readonly opcoes: readonly OpcaoRadio[]
+  readonly desabilitado?: boolean
+  /** Nome acessível do grupo — sem ele o leitor anuncia opções sem dizer do quê. */
+  readonly rotulo?: string
+  readonly orientacao?: 'vertical' | 'horizontal'
+}
+
+export function RadioGroup({
+  valor,
+  onMudar,
+  opcoes,
+  desabilitado = false,
+  rotulo,
+  orientacao = 'vertical',
+  ...campo
+}: RadioGroupProps): React.JSX.Element {
+  return (
+    <RadixRadioGroup.Root
+      {...campo}
+      value={valor}
+      onValueChange={onMudar}
+      disabled={desabilitado}
+      aria-label={rotulo}
+      orientation={orientacao}
+      className={cx('flex gap-3', orientacao === 'vertical' ? 'flex-col' : 'flex-row flex-wrap')}
+    >
+      {opcoes.map((o) => (
+        <ItemRadio key={o.valor} opcao={o} desabilitadoGrupo={desabilitado} />
+      ))}
+    </RadixRadioGroup.Root>
+  )
+}
+
+function ItemRadio({
+  opcao,
+  desabilitadoGrupo
+}: {
+  readonly opcao: OpcaoRadio
+  readonly desabilitadoGrupo: boolean
+}): React.JSX.Element {
+  const id = useId()
+  const inativo = desabilitadoGrupo || opcao.desabilitada === true
+
+  return (
+    <div className="flex items-center gap-2.5">
+      <RadixRadioGroup.Item
+        id={id}
+        value={opcao.valor}
+        disabled={opcao.desabilitada}
+        className={cx(
+          'flex size-[20px] shrink-0 items-center justify-center rounded-full border',
+          'border-[rgba(var(--jos-borda-rgb),0.24)]',
+          SUPERFICIE,
+          'data-[state=checked]:border-[var(--jos-cor-acento)]',
+          FOCO,
+          TRANSICAO,
+          DESABILITADO
+        )}
+      >
+        {/* Ponto interno preenchido: a marca é geométrica, não só cromática. */}
+        <RadixRadioGroup.Indicator className="size-2.5 rounded-full bg-[var(--jos-cor-acento)]" />
+      </RadixRadioGroup.Item>
+      <label
+        htmlFor={id}
+        className={cx(
+          'cursor-pointer text-[14px] text-[var(--jos-cor-texto)]',
+          inativo && 'cursor-not-allowed opacity-45'
+        )}
+      >
+        {opcao.rotulo}
+      </label>
+    </div>
+  )
+}
+
+interface SliderProps extends Partial<AtributosDoControle> {
+  readonly valor: number
+  readonly onMudar: (valor: number) => void
+  readonly minimo?: number
+  readonly maximo?: number
+  readonly passo?: number
+  readonly desabilitado?: boolean
+  readonly rotulo: string
+  /** Formata o valor exibido — `(v) => v + '%'`, por exemplo. */
+  readonly formatar?: (valor: number) => string
+}
+
+/**
+ * Faixa numérica.
+ *
+ * O **valor aparece em texto** ao lado do controle, com algarismos tabulares: uma posição de
+ * alça sozinha não informa o número, e quem usa lupa ou leitor de tela precisa do valor
+ * legível. O `aria-valuetext` do Radix leva a versão formatada para a tecnologia assistiva.
+ */
+export function Slider({
+  valor,
+  onMudar,
+  minimo = 0,
+  maximo = 100,
+  passo = 1,
+  desabilitado = false,
+  rotulo,
+  formatar = (v) => String(v),
+  ...campo
+}: SliderProps): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-3">
+      <RadixSlider.Root
+        {...campo}
+        value={[valor]}
+        onValueChange={([v]) => onMudar(v)}
+        min={minimo}
+        max={maximo}
+        step={passo}
+        disabled={desabilitado}
+        aria-label={rotulo}
+        aria-valuetext={formatar(valor)}
+        className={cx(
+          'relative flex h-5 w-full flex-1 touch-none select-none items-center',
+          desabilitado && 'opacity-45'
+        )}
+      >
+        <RadixSlider.Track className="relative h-1 w-full grow rounded-full bg-[rgba(var(--jos-borda-rgb),0.16)]">
+          <RadixSlider.Range className="absolute h-full rounded-full bg-[var(--jos-cor-acento)]" />
+        </RadixSlider.Track>
+        <RadixSlider.Thumb
+          className={cx(
+            'block size-4 rounded-full border-2 border-[var(--jos-cor-acento)]',
+            'bg-[var(--jos-cor-superficie-elevada)]',
+            FOCO,
+            TRANSICAO
+          )}
+        />
+      </RadixSlider.Root>
+      <span
+        className={cx(
+          LABEL_MONO,
+          'w-12 shrink-0 text-right text-[var(--jos-cor-texto)] [font-variant-numeric:tabular-nums]'
+        )}
+      >
+        {formatar(valor)}
+      </span>
+    </div>
+  )
+}

--- a/src/design/ui/Controles.tsx
+++ b/src/design/ui/Controles.tsx
@@ -4,7 +4,7 @@ import * as RadixRadioGroup from '@radix-ui/react-radio-group'
 import * as RadixSlider from '@radix-ui/react-slider'
 import { Check, Minus } from 'lucide-react'
 import type { AtributosDoControle } from './Field'
-import { cx, DESABILITADO, FOCO, LABEL_MONO, SUPERFICIE, TRANSICAO } from './base'
+import { cx, DESABILITADO, FOCO, SUPERFICIE, TRANSICAO } from './base'
 
 /**
  * Controles de escolha e faixa (SPEC-DesignSystem-03a, PRD §11.2; critério 3).
@@ -13,13 +13,15 @@ import { cx, DESABILITADO, FOCO, LABEL_MONO, SUPERFICIE, TRANSICAO } from './bas
  * `@radix-ui/*` nem compõe `Root`/`Item`/`Indicator`. O que ele passa é dado (`opcoes`,
  * `valor`) e callbacks tipados.
  *
- * O alvo de toque respeita WCAG 2.2 (2.5.8): a caixa desenhada tem 18–20px, mas a área
- * clicável inclui o rótulo, que é o que o `label` envolvente garante.
+ * O alvo de toque respeita a WCAG 2.2 SC 2.5.8 (AA, 24px): a caixa desenhada do checkbox e do
+ * radio tem 20px, mas o alvo real inclui o **rótulo clicável** (`htmlFor` + `useId`), que o
+ * estende bem além do mínimo. A alça do slider não tem rótulo adjacente e por isso usa os 24px
+ * cheios (`--jos-tamanho-alvo-minimo`).
  */
 
 const CAIXA = cx(
   'flex size-[var(--jos-tamanho-marcador)] shrink-0 items-center justify-center rounded-[var(--jos-raio-chip)] border',
-  'border-[rgba(var(--jos-borda-rgb),0.24)]',
+  'border-[rgba(var(--jos-borda-rgb),0.48)]',
   SUPERFICIE,
   // Marcado: fundo no acento **e** o ícone de check. O ícone é o que sobrevive ao alto
   // contraste e ao daltonismo — cor sozinha não comunica estado (critério 2).
@@ -140,7 +142,7 @@ function ItemRadio({
         disabled={opcao.desabilitada}
         className={cx(
           'flex size-[var(--jos-tamanho-marcador)] shrink-0 items-center justify-center rounded-full border',
-          'border-[rgba(var(--jos-borda-rgb),0.24)]',
+          'border-[rgba(var(--jos-borda-rgb),0.48)]',
           SUPERFICIE,
           'data-[state=checked]:border-[var(--jos-cor-acento)]',
           FOCO,
@@ -205,7 +207,9 @@ export function Slider({
         step={passo}
         disabled={desabilitado}
         className={cx(
-          'relative flex h-5 w-full flex-1 touch-none select-none items-center',
+          // A linha acomoda a alça de 24px: com h-5 (20px) a alça vazaria o container e a área
+          // clicável ficaria cortada em cima e embaixo.
+          'relative flex h-6 w-full flex-1 touch-none select-none items-center',
           desabilitado && 'opacity-45'
         )}
       >
@@ -217,21 +221,34 @@ export function Slider({
           o Thumb, e é nele que o leitor de tela procura `aria-label`/`aria-valuetext`. Pôr no
           Root deixa a faixa anônima — foi o que os testes pegaram.
         */}
+        {/*
+          Alça de 24px — o mínimo da WCAG 2.2 SC 2.5.8 (AA) para alvo de ponteiro. A primeira
+          versão usava 16px: diferente do checkbox, que amplia o alvo pelo rótulo clicável, a
+          alça não tem nada adjacente que a estenda. Era o único alvo abaixo da régua.
+        */}
         <RadixSlider.Thumb
           aria-label={rotulo}
           aria-valuetext={formatar(valor)}
           className={cx(
-            'block size-4 rounded-full border-2 border-[var(--jos-cor-acento)]',
-            'bg-[var(--jos-cor-superficie-elevada)]',
+            'block size-[var(--jos-tamanho-alvo-minimo)] rounded-full border-2',
+            'border-[var(--jos-cor-acento)] bg-[var(--jos-cor-superficie-elevada)]',
             FOCO,
             TRANSICAO
           )}
         />
       </RadixSlider.Root>
+      {/*
+        O valor é **valor**, não label: fonte mono e tabular para não dançar a cada tick, mas no
+        tamanho e na cor do corpo. Usar `LABEL_MONO` aqui vestia um dado com roupa de rótulo —
+        uppercase, cor apagada — e depois sobrescrevia a cor de volta.
+        `min-w` e não `w`: `formatar` é API pública e sua saída não tem tamanho contratado
+        (`1200ms`, `R$ 1.500`); largura fixa clipava em vez de crescer.
+      */}
       <span
         className={cx(
-          LABEL_MONO,
-          'w-12 shrink-0 text-right text-[var(--jos-cor-texto)] [font-variant-numeric:tabular-nums]'
+          'min-w-14 shrink-0 text-right',
+          'font-[family-name:var(--jos-fonte-mono)] text-[length:var(--jos-texto-corpo)]',
+          'text-[var(--jos-cor-texto)] [font-variant-numeric:tabular-nums]'
         )}
       >
         {formatar(valor)}

--- a/src/design/ui/Controles.tsx
+++ b/src/design/ui/Controles.tsx
@@ -18,7 +18,7 @@ import { cx, DESABILITADO, FOCO, LABEL_MONO, SUPERFICIE, TRANSICAO } from './bas
  */
 
 const CAIXA = cx(
-  'flex size-[20px] shrink-0 items-center justify-center rounded-[5px] border',
+  'flex size-[var(--jos-tamanho-marcador)] shrink-0 items-center justify-center rounded-[var(--jos-raio-chip)] border',
   'border-[rgba(var(--jos-borda-rgb),0.24)]',
   SUPERFICIE,
   // Marcado: fundo no acento **e** o ícone de check. O ícone é o que sobrevive ao alto
@@ -70,7 +70,7 @@ export function Checkbox({
       <label
         htmlFor={id}
         className={cx(
-          'cursor-pointer text-[14px] text-[var(--jos-cor-texto)]',
+          'cursor-pointer text-[length:var(--jos-texto-corpo)] text-[var(--jos-cor-texto)]',
           desabilitado && 'cursor-not-allowed opacity-45'
         )}
       >
@@ -139,7 +139,7 @@ function ItemRadio({
         value={opcao.valor}
         disabled={opcao.desabilitada}
         className={cx(
-          'flex size-[20px] shrink-0 items-center justify-center rounded-full border',
+          'flex size-[var(--jos-tamanho-marcador)] shrink-0 items-center justify-center rounded-full border',
           'border-[rgba(var(--jos-borda-rgb),0.24)]',
           SUPERFICIE,
           'data-[state=checked]:border-[var(--jos-cor-acento)]',
@@ -154,7 +154,7 @@ function ItemRadio({
       <label
         htmlFor={id}
         className={cx(
-          'cursor-pointer text-[14px] text-[var(--jos-cor-texto)]',
+          'cursor-pointer text-[length:var(--jos-texto-corpo)] text-[var(--jos-cor-texto)]',
           inativo && 'cursor-not-allowed opacity-45'
         )}
       >

--- a/src/design/ui/Field.tsx
+++ b/src/design/ui/Field.tsx
@@ -110,7 +110,9 @@ export function FormMessage({ mensagem, tom, id }: FormMessageProps): React.JSX.
       role={erro ? 'alert' : undefined}
       className={cx(
         'flex items-start gap-1.5 text-[length:var(--jos-texto-mini)] leading-snug',
-        erro ? 'text-[var(--jos-cor-err)]' : 'text-[var(--jos-cor-texto-suave)]'
+        // Texto lê a variante **de leitura**: a cor de marca #ff6b81 mede 2.53:1 no modo claro.
+        // Borda e ícone continuam usando a cor de marca — só o texto precisa da régua de 4.5:1.
+        erro ? 'text-[var(--jos-cor-err-leitura)]' : 'text-[var(--jos-cor-texto-suave)]'
       )}
     >
       <Icone aria-hidden="true" className="mt-px size-3.5 shrink-0" />

--- a/src/design/ui/Field.tsx
+++ b/src/design/ui/Field.tsx
@@ -109,7 +109,7 @@ export function FormMessage({ mensagem, tom, id }: FormMessageProps): React.JSX.
       id={id}
       role={erro ? 'alert' : undefined}
       className={cx(
-        'flex items-start gap-1.5 text-[12px] leading-snug',
+        'flex items-start gap-1.5 text-[length:var(--jos-texto-mini)] leading-snug',
         erro ? 'text-[var(--jos-cor-err)]' : 'text-[var(--jos-cor-texto-suave)]'
       )}
     >

--- a/src/design/ui/Field.tsx
+++ b/src/design/ui/Field.tsx
@@ -1,0 +1,120 @@
+import { useId } from 'react'
+import { AlertCircle, Info } from 'lucide-react'
+import { cx, LABEL_MONO } from './base'
+
+/**
+ * Campo de formulário: rótulo, controle, descrição e mensagem (SPEC-DesignSystem-03a §11.2).
+ *
+ * `Field` existe para resolver **uma** coisa que quase todo formulário erra: a ligação entre o
+ * controle e os textos que o descrevem. Ele gera os ids e devolve, por render prop, o conjunto
+ * de atributos ARIA que o controle precisa vestir. Sem isso, cada componente teria de lembrar
+ * de fazer `aria-describedby` apontar para a descrição *e* para o erro — e um dia um esquece.
+ *
+ * Por que render prop e não contexto: o controle precisa dos atributos **no próprio elemento**,
+ * e uma prop explícita torna impossível renderizar o campo sem ligá-los.
+ */
+
+/** Atributos que o controle deve receber para ficar corretamente descrito. */
+export interface AtributosDoControle {
+  readonly id: string
+  readonly 'aria-describedby': string | undefined
+  readonly 'aria-invalid': boolean | undefined
+  readonly 'aria-required': boolean | undefined
+}
+
+interface FieldProps {
+  readonly rotulo: string
+  /** Texto de apoio permanente — some quando há erro, para não competir com ele. */
+  readonly descricao?: string
+  /** Mensagem de erro. Presente ⇒ o campo está inválido. */
+  readonly erro?: string
+  readonly obrigatorio?: boolean
+  readonly children: (atributos: AtributosDoControle) => React.ReactNode
+}
+
+export function Field({
+  rotulo,
+  descricao,
+  erro,
+  obrigatorio = false,
+  children
+}: FieldProps): React.JSX.Element {
+  const base = useId()
+  const idControle = `${base}-controle`
+  const idDescricao = `${base}-descricao`
+  const idErro = `${base}-erro`
+
+  const invalido = erro !== undefined && erro !== ''
+
+  // Erro primeiro na ordem de leitura: quem acabou de errar precisa ouvir o problema antes da
+  // instrução genérica. Sem erro, resta só a descrição.
+  const descritoPor = [invalido ? idErro : null, descricao ? idDescricao : null]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label htmlFor={idControle} className={cx(LABEL_MONO, 'flex items-center gap-1.5')}>
+        {rotulo}
+        {obrigatorio && (
+          <>
+            {/* O asterisco é decorativo — quem informa a obrigatoriedade é `aria-required` no
+                controle. Um `*` sozinho é convenção visual que nem todo usuário conhece. */}
+            <span aria-hidden="true" className="text-[var(--jos-cor-err)]">
+              *
+            </span>
+            <span className="sr-only">(obrigatório)</span>
+          </>
+        )}
+      </label>
+
+      {children({
+        id: idControle,
+        'aria-describedby': descritoPor === '' ? undefined : descritoPor,
+        'aria-invalid': invalido || undefined,
+        'aria-required': obrigatorio || undefined
+      })}
+
+      {invalido && <FormMessage id={idErro} tom="erro" mensagem={erro} />}
+      {!invalido && descricao !== undefined && (
+        <FormMessage id={idDescricao} tom="apoio" mensagem={descricao} />
+      )}
+    </div>
+  )
+}
+
+interface FormMessageProps {
+  readonly mensagem: string
+  readonly tom: 'erro' | 'apoio'
+  readonly id?: string
+}
+
+/**
+ * Mensagem de campo (critério 4).
+ *
+ * Erro carrega **ícone + texto + `role="alert"`**, nunca só cor vermelha: daltonismo, alto
+ * contraste e leitor de tela precisam do mesmo sinal por caminhos diferentes.
+ *
+ * A spec exige que o erro traga *problema **e** próxima ação*. Isso não dá para forçar por
+ * tipo — quem escreve a mensagem é o consumidor. O que o componente faz é não atrapalhar:
+ * `role="alert"` anuncia a mensagem inteira assim que ela aparece, e há teste cobrando o
+ * formato nas mensagens que o DS oferece.
+ */
+export function FormMessage({ mensagem, tom, id }: FormMessageProps): React.JSX.Element {
+  const erro = tom === 'erro'
+  const Icone = erro ? AlertCircle : Info
+
+  return (
+    <p
+      id={id}
+      role={erro ? 'alert' : undefined}
+      className={cx(
+        'flex items-start gap-1.5 text-[12px] leading-snug',
+        erro ? 'text-[var(--jos-cor-err)]' : 'text-[var(--jos-cor-texto-suave)]'
+      )}
+    >
+      <Icone aria-hidden="true" className="mt-px size-3.5 shrink-0" />
+      <span>{mensagem}</span>
+    </p>
+  )
+}

--- a/src/design/ui/IconButton.tsx
+++ b/src/design/ui/IconButton.tsx
@@ -1,0 +1,60 @@
+import { ALTURA_CONTROLE, BORDA, cx, DESABILITADO, FOCO, SUPERFICIE, TRANSICAO } from './base'
+
+/**
+ * Botão só de ícone (SPEC-DesignSystem-03a, PRD §11.1).
+ *
+ * `rotulo` é **obrigatório** e não tem default: um botão de ícone sem nome acessível é um botão
+ * que o leitor de tela anuncia como "botão", e nada mais. Fazer a prop obrigatória é o que
+ * transforma essa regra em erro de compilação em vez de achado de auditoria.
+ */
+
+interface IconButtonProps {
+  /** Nome acessível — o que o leitor de tela anuncia. Obrigatório por desenho. */
+  readonly rotulo: string
+  readonly children: React.ReactNode
+  readonly onClick?: () => void
+  readonly desabilitado?: boolean
+  /** Marca o botão como ativo (`aria-pressed`) — para toggles de barra de ferramentas. */
+  readonly ativo?: boolean
+  readonly tipo?: 'button' | 'submit'
+}
+
+export function IconButton({
+  rotulo,
+  children,
+  onClick,
+  desabilitado = false,
+  ativo,
+  tipo = 'button'
+}: IconButtonProps): React.JSX.Element {
+  return (
+    <button
+      type={tipo}
+      onClick={onClick}
+      disabled={desabilitado}
+      aria-label={rotulo}
+      aria-pressed={ativo}
+      title={rotulo}
+      style={{ height: ALTURA_CONTROLE, width: ALTURA_CONTROLE }}
+      className={cx(
+        'inline-flex items-center justify-center rounded-[var(--jos-raio-rail)]',
+        BORDA,
+        SUPERFICIE,
+        'text-[var(--jos-cor-texto-secundario)]',
+        'hover:text-[var(--jos-cor-texto)] hover:border-[rgba(var(--jos-borda-rgb),0.24)]',
+        // Estado ativo carrega borda **e** cor de texto: só a cor de fundo seria diferença que
+        // some no alto contraste (critério 2 — nunca só por cor).
+        ativo === true &&
+          'border-[var(--jos-cor-acento)] text-[var(--jos-cor-acento-leitura)] bg-[color-mix(in_srgb,var(--jos-cor-acento)_12%,transparent)]',
+        FOCO,
+        TRANSICAO,
+        DESABILITADO
+      )}
+    >
+      {/* O ícone é decorativo: quem nomeia o botão é o `aria-label`. */}
+      <span aria-hidden="true" className="inline-flex">
+        {children}
+      </span>
+    </button>
+  )
+}

--- a/src/design/ui/Input.tsx
+++ b/src/design/ui/Input.tsx
@@ -14,7 +14,7 @@ import { ALTURA_CONTROLE, BORDA, cx, DESABILITADO, FOCO, SUPERFICIE, TRANSICAO }
  */
 
 const CLASSES_CAMPO = cx(
-  'w-full rounded-[var(--jos-raio-card)] px-3.5 text-[14px]',
+  'w-full rounded-[var(--jos-raio-card)] px-3.5 text-[length:var(--jos-texto-corpo)]',
   'font-[family-name:var(--jos-fonte-corpo)] text-[var(--jos-cor-texto)]',
   BORDA,
   SUPERFICIE,

--- a/src/design/ui/Input.tsx
+++ b/src/design/ui/Input.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
+import type { AtributosDoControle } from './Field'
+import { ALTURA_CONTROLE, BORDA, cx, DESABILITADO, FOCO, SUPERFICIE, TRANSICAO } from './base'
+
+/**
+ * Campos de texto (SPEC-DesignSystem-03a, PRD §11.2).
+ *
+ * A forma vem da tela de login do protótipo: 44px de altura, raio de card, borda neutra de
+ * baixo alfa, ícone opcional à esquerda, placeholder discreto.
+ *
+ * Os atributos ARIA chegam prontos do `Field` (`...campo`) em vez de cada uso montar o
+ * `aria-describedby` à mão — é o que garante que o erro seja anunciado junto com o campo.
+ */
+
+const CLASSES_CAMPO = cx(
+  'w-full rounded-[var(--jos-raio-card)] px-3.5 text-[14px]',
+  'font-[family-name:var(--jos-fonte-corpo)] text-[var(--jos-cor-texto)]',
+  BORDA,
+  SUPERFICIE,
+  // O placeholder usa a cor de texto suave, que o tema garante com contraste — o cinza-claro
+  // "elegante" é a causa nº 1 de campo ilegível.
+  'placeholder:text-[var(--jos-cor-texto-suave)]',
+  // Borda vermelha **acompanha** o ícone e o texto do FormMessage: cor nunca sozinha.
+  'aria-[invalid=true]:border-[var(--jos-cor-err)]',
+  FOCO,
+  TRANSICAO,
+  DESABILITADO
+)
+
+interface InputProps extends Partial<AtributosDoControle> {
+  readonly valor: string
+  readonly onMudar: (valor: string) => void
+  readonly placeholder?: string
+  readonly desabilitado?: boolean
+  readonly tipo?: 'text' | 'email' | 'search' | 'url' | 'tel'
+  /** Ícone à esquerda — decorativo; quem nomeia o campo é o rótulo do `Field`. */
+  readonly icone?: React.ReactNode
+  readonly autoComplete?: string
+}
+
+export function Input({
+  valor,
+  onMudar,
+  placeholder,
+  desabilitado = false,
+  tipo = 'text',
+  icone,
+  autoComplete,
+  ...campo
+}: InputProps): React.JSX.Element {
+  return (
+    <div className="relative flex items-center">
+      {icone !== undefined && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3.5 flex text-[var(--jos-cor-texto-suave)]"
+        >
+          {icone}
+        </span>
+      )}
+      <input
+        {...campo}
+        type={tipo}
+        value={valor}
+        onChange={(e) => onMudar(e.target.value)}
+        placeholder={placeholder}
+        disabled={desabilitado}
+        autoComplete={autoComplete}
+        style={{ height: ALTURA_CONTROLE }}
+        className={cx(CLASSES_CAMPO, icone !== undefined && 'pl-10')}
+      />
+    </div>
+  )
+}
+
+interface PasswordInputProps extends Partial<AtributosDoControle> {
+  readonly valor: string
+  readonly onMudar: (valor: string) => void
+  readonly placeholder?: string
+  readonly desabilitado?: boolean
+  readonly icone?: React.ReactNode
+  readonly autoComplete?: string
+}
+
+/**
+ * Campo de senha com alternância de visibilidade (PRD §11.2 e §15).
+ *
+ * O botão de revelar é um `button` de verdade, com `aria-pressed` e rótulo que muda — não um
+ * ícone clicável. Assim ele entra na ordem de tabulação e o leitor de tela informa se a senha
+ * está visível.
+ *
+ * **`autoComplete` default `current-password`** e nada de `value` em superfície de resumo: a
+ * spec cita PRD §15 (sem cópia acidental). O campo não expõe API para renderizar o valor em
+ * outro lugar — quem quiser fazê-lo terá de escrever, e não herdar por descuido.
+ */
+export function PasswordInput({
+  valor,
+  onMudar,
+  placeholder,
+  desabilitado = false,
+  icone,
+  autoComplete = 'current-password',
+  ...campo
+}: PasswordInputProps): React.JSX.Element {
+  const [visivel, setVisivel] = useState(false)
+
+  return (
+    <div className="relative flex items-center">
+      {icone !== undefined && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3.5 flex text-[var(--jos-cor-texto-suave)]"
+        >
+          {icone}
+        </span>
+      )}
+      <input
+        {...campo}
+        type={visivel ? 'text' : 'password'}
+        value={valor}
+        onChange={(e) => onMudar(e.target.value)}
+        placeholder={placeholder}
+        disabled={desabilitado}
+        autoComplete={autoComplete}
+        style={{ height: ALTURA_CONTROLE }}
+        className={cx(CLASSES_CAMPO, icone !== undefined && 'pl-10', 'pr-11')}
+      />
+      <button
+        type="button"
+        onClick={() => setVisivel(!visivel)}
+        disabled={desabilitado}
+        aria-pressed={visivel}
+        aria-label={visivel ? 'Ocultar senha' : 'Mostrar senha'}
+        className={cx(
+          'absolute right-2 flex size-8 items-center justify-center rounded-[var(--jos-raio-chip)]',
+          'text-[var(--jos-cor-texto-suave)] hover:text-[var(--jos-cor-texto)]',
+          FOCO,
+          TRANSICAO,
+          DESABILITADO
+        )}
+      >
+        {visivel ? (
+          <EyeOff aria-hidden="true" className="size-4" />
+        ) : (
+          <Eye aria-hidden="true" className="size-4" />
+        )}
+      </button>
+    </div>
+  )
+}
+
+interface TextareaProps extends Partial<AtributosDoControle> {
+  readonly valor: string
+  readonly onMudar: (valor: string) => void
+  readonly placeholder?: string
+  readonly desabilitado?: boolean
+  readonly linhas?: number
+}
+
+export function Textarea({
+  valor,
+  onMudar,
+  placeholder,
+  desabilitado = false,
+  linhas = 4,
+  ...campo
+}: TextareaProps): React.JSX.Element {
+  return (
+    <textarea
+      {...campo}
+      value={valor}
+      onChange={(e) => onMudar(e.target.value)}
+      placeholder={placeholder}
+      disabled={desabilitado}
+      rows={linhas}
+      // `resize-y` e não `resize`: redimensionar na horizontal quebra o layout do formulário,
+      // e a medida de leitura é decisão do design, não do arrasto.
+      className={cx(CLASSES_CAMPO, 'resize-y py-3 leading-relaxed')}
+    />
+  )
+}

--- a/src/design/ui/Link.tsx
+++ b/src/design/ui/Link.tsx
@@ -34,7 +34,7 @@ export function Link({ href, children, externo = false }: LinkProps): React.JSX.
         'inline-flex items-center gap-1 underline underline-offset-4',
         'text-[var(--jos-cor-acento-leitura)] decoration-[rgba(var(--jos-borda-rgb),0.4)]',
         'hover:decoration-[var(--jos-cor-acento)]',
-        'outline-none focus-visible:rounded-[4px] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-[var(--jos-cor-acento)]',
+        'outline-none focus-visible:rounded-[var(--jos-raio-chip)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-[var(--jos-cor-acento)]',
         TRANSICAO
       )}
     >

--- a/src/design/ui/Link.tsx
+++ b/src/design/ui/Link.tsx
@@ -1,0 +1,52 @@
+import { cx, TRANSICAO } from './base'
+
+/**
+ * Link (SPEC-DesignSystem-03a, PRD §11.1).
+ *
+ * **Link navega, botão age** — a distinção não é estética, é o que o leitor de tela anuncia e
+ * o que o teclado faz (Enter num link, Enter *e* Espaço num botão). Um `<a>` sem `href` que
+ * dispara `onClick` é a armadilha clássica: parece link, não recebe foco, não abre em nova
+ * aba. Por isso `href` é obrigatório aqui; ação sem navegação usa `Button`.
+ *
+ * Sublinhado por padrão: cor sozinha não distingue link de texto (PRD §14, WCAG 1.4.1) — e é
+ * exatamente o caso que o critério 2 desta fatia cobra.
+ */
+
+interface LinkProps {
+  readonly href: string
+  readonly children: React.ReactNode
+  /**
+   * Link externo — abre em nova aba com `rel` seguro e anuncia o destino.
+   *
+   * `noopener` não é opcional: sem ele a página aberta ganha acesso a `window.opener` e pode
+   * navegar a origem para outro lugar.
+   */
+  readonly externo?: boolean
+}
+
+export function Link({ href, children, externo = false }: LinkProps): React.JSX.Element {
+  return (
+    <a
+      href={href}
+      target={externo ? '_blank' : undefined}
+      rel={externo ? 'noopener noreferrer' : undefined}
+      className={cx(
+        'inline-flex items-center gap-1 underline underline-offset-4',
+        'text-[var(--jos-cor-acento-leitura)] decoration-[rgba(var(--jos-borda-rgb),0.4)]',
+        'hover:decoration-[var(--jos-cor-acento)]',
+        'outline-none focus-visible:rounded-[4px] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-[var(--jos-cor-acento)]',
+        TRANSICAO
+      )}
+    >
+      {children}
+      {externo && (
+        <>
+          {/* O ícone é decorativo; quem informa "abre em nova aba" é o texto abaixo, que fica
+              visível só para tecnologia assistiva. Ícone sozinho não chega a quem não o vê. */}
+          <span aria-hidden="true">↗</span>
+          <span className="sr-only">(abre em nova aba)</span>
+        </>
+      )}
+    </a>
+  )
+}

--- a/src/design/ui/Select.tsx
+++ b/src/design/ui/Select.tsx
@@ -45,7 +45,7 @@ export function Select({
         style={{ height: ALTURA_CONTROLE }}
         className={cx(
           'inline-flex w-full items-center justify-between gap-2 rounded-[var(--jos-raio-card)] px-3.5',
-          'text-[14px] font-[family-name:var(--jos-fonte-corpo)] text-[var(--jos-cor-texto)]',
+          'text-[length:var(--jos-texto-corpo)] font-[family-name:var(--jos-fonte-corpo)] text-[var(--jos-cor-texto)]',
           BORDA,
           SUPERFICIE,
           'data-[placeholder]:text-[var(--jos-cor-texto-suave)]',
@@ -80,7 +80,7 @@ export function Select({
                 disabled={o.desabilitada}
                 className={cx(
                   'relative flex cursor-default select-none items-center gap-2 rounded-[var(--jos-raio-chip)]',
-                  'py-2 pl-8 pr-3 text-[14px] text-[var(--jos-cor-texto)] outline-none',
+                  'py-2 pl-8 pr-3 text-[length:var(--jos-texto-corpo)] text-[var(--jos-cor-texto)] outline-none',
                   'data-[highlighted]:bg-[color-mix(in_srgb,var(--jos-cor-acento)_14%,transparent)]',
                   'data-[disabled]:opacity-45'
                 )}

--- a/src/design/ui/Select.tsx
+++ b/src/design/ui/Select.tsx
@@ -1,0 +1,100 @@
+import * as RadixSelect from '@radix-ui/react-select'
+import { Check, ChevronDown } from 'lucide-react'
+import type { AtributosDoControle } from './Field'
+import { ALTURA_CONTROLE, BORDA, cx, DESABILITADO, FOCO, SUPERFICIE, TRANSICAO } from './base'
+
+/**
+ * Seleção de uma opção (SPEC-DesignSystem-03a, PRD §11.2; critério 3).
+ *
+ * Encapsula o `Select` do Radix — teclado, `aria-activedescendant`, foco em portal e navegação
+ * por digitação vêm prontos. A **superfície pública é própria**: o consumidor passa uma lista
+ * de `{ valor, rotulo }` e não vê `Select.Root`/`Trigger`/`Portal`. Expor a composição do
+ * Radix transformaria a API dele em contrato do DS, e trocar de primitivo passaria a quebrar
+ * todo consumidor.
+ *
+ * O conteúdo vai para **portal** de propósito: um dropdown `position: absolute` dentro de um
+ * container com `overflow: hidden` é cortado — armadilha clássica em painel com rolagem.
+ */
+
+export interface OpcaoSelect {
+  readonly valor: string
+  readonly rotulo: string
+  readonly desabilitada?: boolean
+}
+
+interface SelectProps extends Partial<AtributosDoControle> {
+  readonly valor: string
+  readonly onMudar: (valor: string) => void
+  readonly opcoes: readonly OpcaoSelect[]
+  readonly placeholder?: string
+  readonly desabilitado?: boolean
+}
+
+export function Select({
+  valor,
+  onMudar,
+  opcoes,
+  placeholder = 'Selecione',
+  desabilitado = false,
+  ...campo
+}: SelectProps): React.JSX.Element {
+  return (
+    <RadixSelect.Root value={valor} onValueChange={onMudar} disabled={desabilitado}>
+      <RadixSelect.Trigger
+        {...campo}
+        style={{ height: ALTURA_CONTROLE }}
+        className={cx(
+          'inline-flex w-full items-center justify-between gap-2 rounded-[var(--jos-raio-card)] px-3.5',
+          'text-[14px] font-[family-name:var(--jos-fonte-corpo)] text-[var(--jos-cor-texto)]',
+          BORDA,
+          SUPERFICIE,
+          'data-[placeholder]:text-[var(--jos-cor-texto-suave)]',
+          'aria-[invalid=true]:border-[var(--jos-cor-err)]',
+          FOCO,
+          TRANSICAO,
+          DESABILITADO
+        )}
+      >
+        <RadixSelect.Value placeholder={placeholder} />
+        <RadixSelect.Icon>
+          <ChevronDown aria-hidden="true" className="size-4 opacity-70" />
+        </RadixSelect.Icon>
+      </RadixSelect.Trigger>
+
+      <RadixSelect.Portal>
+        <RadixSelect.Content
+          position="popper"
+          sideOffset={6}
+          className={cx(
+            'z-[var(--jos-camada-overlay)] min-w-[var(--radix-select-trigger-width)] overflow-hidden',
+            'rounded-[var(--jos-raio-card)] shadow-[var(--jos-sombra-card)]',
+            BORDA,
+            'bg-[var(--jos-cor-superficie-elevada)]'
+          )}
+        >
+          <RadixSelect.Viewport className="p-1">
+            {opcoes.map((o) => (
+              <RadixSelect.Item
+                key={o.valor}
+                value={o.valor}
+                disabled={o.desabilitada}
+                className={cx(
+                  'relative flex cursor-default select-none items-center gap-2 rounded-[var(--jos-raio-chip)]',
+                  'py-2 pl-8 pr-3 text-[14px] text-[var(--jos-cor-texto)] outline-none',
+                  'data-[highlighted]:bg-[color-mix(in_srgb,var(--jos-cor-acento)_14%,transparent)]',
+                  'data-[disabled]:opacity-45'
+                )}
+              >
+                {/* O item selecionado carrega **check + destaque**, não só cor de fundo. */}
+                <RadixSelect.ItemIndicator className="absolute left-2 flex">
+                  <Check aria-hidden="true" className="size-4" />
+                </RadixSelect.ItemIndicator>
+                <RadixSelect.ItemText>{o.rotulo}</RadixSelect.ItemText>
+              </RadixSelect.Item>
+            ))}
+          </RadixSelect.Viewport>
+        </RadixSelect.Content>
+      </RadixSelect.Portal>
+    </RadixSelect.Root>
+  )
+}

--- a/src/design/ui/acoes.test.tsx
+++ b/src/design/ui/acoes.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { Button, ButtonGroup, IconButton, Link } from './index'
+
+/**
+ * Ações (SPEC-DesignSystem-03a, critérios 1, 2 e 6; PRD §11.1).
+ *
+ * Tudo é consultado **por papel** (`getByRole`), nunca por classe: o critério é o que o leitor
+ * de tela anuncia, não a marcação interna. Um teste que casasse por `className` passaria com o
+ * componente inacessível.
+ */
+
+describe('Button', () => {
+  it('é acionável por teclado e por clique', async () => {
+    const onClick = vi.fn()
+    render(<Button onClick={onClick}>Salvar</Button>)
+
+    const botao = screen.getByRole('button', { name: 'Salvar' })
+    botao.focus()
+    expect(botao).toHaveFocus()
+
+    // Enter **e** Espaço: é o contrato de `<button>`, e é o que o distingue de um `<div>`
+    // clicável. Se alguém trocar por div com onClick, este teste cai.
+    await userEvent.keyboard('{Enter}')
+    await userEvent.keyboard(' ')
+    expect(onClick).toHaveBeenCalledTimes(2)
+
+    await userEvent.click(botao)
+    expect(onClick).toHaveBeenCalledTimes(3)
+  })
+
+  it('desabilitado não dispara e é anunciado como desabilitado', async () => {
+    const onClick = vi.fn()
+    render(
+      <Button onClick={onClick} desabilitado>
+        Salvar
+      </Button>
+    )
+
+    const botao = screen.getByRole('button', { name: 'Salvar' })
+    expect(botao).toBeDisabled()
+    await userEvent.click(botao)
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  describe('carregando (critério 2 — estado nunca só por cor)', () => {
+    it('anuncia por aria-busy e por texto, não só pelo spinner', () => {
+      render(<Button carregando>Salvar</Button>)
+
+      const botao = screen.getByRole('button')
+      expect(botao).toHaveAttribute('aria-busy', 'true')
+      // O texto é o canal que chega a quem não vê o spinner girar.
+      expect(botao).toHaveTextContent(/aguarde/i)
+    })
+
+    it('não aceita segundo clique enquanto carrega', async () => {
+      const onClick = vi.fn()
+      render(
+        <Button onClick={onClick} carregando>
+          Salvar
+        </Button>
+      )
+      await userEvent.click(screen.getByRole('button'))
+      expect(onClick).not.toHaveBeenCalled()
+    })
+  })
+
+  it('o tipo submit existe para formulário — o default não submete por acidente', () => {
+    render(<Button>Ação</Button>)
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
+  })
+
+  it.each(['primaria', 'secundaria', 'perigo'] as const)(
+    'a variante %s continua sendo um button acessível',
+    (variante) => {
+      render(<Button variante={variante}>Ação</Button>)
+      expect(screen.getByRole('button', { name: 'Ação' })).toBeInTheDocument()
+    }
+  )
+})
+
+describe('IconButton', () => {
+  it('tem nome acessível obrigatório — ícone sozinho não nomeia', () => {
+    render(
+      <IconButton rotulo="Fechar painel">
+        <span>×</span>
+      </IconButton>
+    )
+    // O ícone é `aria-hidden`; quem nomeia é o rótulo. Sem isso o leitor anuncia só "botão".
+    expect(screen.getByRole('button', { name: 'Fechar painel' })).toBeInTheDocument()
+  })
+
+  it('estado ativo é exposto por aria-pressed, não só por cor (critério 2)', () => {
+    const { rerender } = render(
+      <IconButton rotulo="Filtrar" ativo={false}>
+        <span>f</span>
+      </IconButton>
+    )
+    expect(screen.getByRole('button', { name: 'Filtrar' })).toHaveAttribute('aria-pressed', 'false')
+
+    rerender(
+      <IconButton rotulo="Filtrar" ativo>
+        <span>f</span>
+      </IconButton>
+    )
+    expect(screen.getByRole('button', { name: 'Filtrar' })).toHaveAttribute('aria-pressed', 'true')
+  })
+})
+
+describe('ButtonGroup', () => {
+  it('agrupa ações independentes como group', () => {
+    render(
+      <ButtonGroup rotulo="Ações do registro">
+        <Button>Cancelar</Button>
+        <Button variante="primaria">Salvar</Button>
+      </ButtonGroup>
+    )
+    expect(screen.getByRole('group', { name: 'Ações do registro' })).toBeInTheDocument()
+  })
+
+  it('opções exclusivas viram radiogroup, não fileira de botões', () => {
+    // Uma barra de botões independentes não anunciaria qual está ativo — mesma lição da F02 do
+    // MVP-001, onde os botões de espaço viraram radiogroup pelo mesmo motivo.
+    render(
+      <ButtonGroup papel="segmentado" rotulo="Modo de exibição">
+        <Button>Lista</Button>
+        <Button>Grade</Button>
+      </ButtonGroup>
+    )
+    expect(screen.getByRole('radiogroup', { name: 'Modo de exibição' })).toBeInTheDocument()
+  })
+})
+
+describe('Link', () => {
+  it('é um link de verdade, com href', () => {
+    render(<Link href="/settings">Configurações</Link>)
+    const link = screen.getByRole('link', { name: 'Configurações' })
+    expect(link).toHaveAttribute('href', '/settings')
+  })
+
+  it('link externo abre com rel seguro e avisa o destino em texto', () => {
+    render(
+      <Link href="https://exemplo.com" externo>
+        Documentação
+      </Link>
+    )
+    const link = screen.getByRole('link', { name: /documenta/i })
+    expect(link).toHaveAttribute('target', '_blank')
+    // `noopener` não é opcional: sem ele a página aberta ganha acesso a `window.opener`.
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    // O aviso é texto, não só a setinha — ícone sozinho não chega a quem não o vê.
+    expect(link).toHaveTextContent(/abre em nova aba/i)
+  })
+})

--- a/src/design/ui/acoes.test.tsx
+++ b/src/design/ui/acoes.test.tsx
@@ -45,13 +45,17 @@ describe('Button', () => {
   })
 
   describe('carregando (critério 2 — estado nunca só por cor)', () => {
-    it('anuncia por aria-busy e por texto, não só pelo spinner', () => {
+    it('anuncia por aria-busy e **preserva o rótulo** da ação', () => {
       render(<Button carregando>Salvar</Button>)
 
       const botao = screen.getByRole('button')
       expect(botao).toHaveAttribute('aria-busy', 'true')
-      // O texto é o canal que chega a quem não vê o spinner girar.
-      expect(botao).toHaveTextContent(/aguarde/i)
+      // A primeira versão trocava o texto por "Aguarde": num console com várias ações em voo,
+      // o usuário deixava de saber *qual* estava rodando, e a largura do botão saltava.
+      // `aria-busy` já leva o estado à tecnologia assistiva — a palavra nunca foi o que
+      // informava. Achado do `/impeccable critique` da F03a.
+      expect(botao).toHaveAccessibleName('Salvar')
+      expect(botao).not.toHaveTextContent(/aguarde/i)
     })
 
     it('não aceita segundo clique enquanto carrega', async () => {
@@ -119,16 +123,19 @@ describe('ButtonGroup', () => {
     expect(screen.getByRole('group', { name: 'Ações do registro' })).toBeInTheDocument()
   })
 
-  it('opções exclusivas viram radiogroup, não fileira de botões', () => {
-    // Uma barra de botões independentes não anunciaria qual está ativo — mesma lição da F02 do
-    // MVP-001, onde os botões de espaço viraram radiogroup pelo mesmo motivo.
+  it('não promete radiogroup — os filhos são botões, não rádios', () => {
+    // A variante `segmentado` aplicava `role="radiogroup"` sobre filhos `<button>`: o leitor de
+    // tela anunciaria um grupo de rádio **sem rádios dentro**, pior que a fileira de botões que
+    // ela tentava corrigir. Removida na F03a (achado do `/impeccable critique`); o controle
+    // segmentado de verdade — com estado e navegação por setas — é escopo da F04a.
     render(
-      <ButtonGroup papel="segmentado" rotulo="Modo de exibição">
+      <ButtonGroup rotulo="Modo de exibição">
         <Button>Lista</Button>
         <Button>Grade</Button>
       </ButtonGroup>
     )
-    expect(screen.getByRole('radiogroup', { name: 'Modo de exibição' })).toBeInTheDocument()
+    expect(screen.queryByRole('radiogroup')).not.toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Modo de exibição' })).toBeInTheDocument()
   })
 })
 

--- a/src/design/ui/base.ts
+++ b/src/design/ui/base.ts
@@ -60,7 +60,7 @@ export const DESABILITADO = 'disabled:opacity-45 disabled:cursor-not-allowed'
 
 /** Label pequena — README §3: mono UPPERCASE com tracking. */
 export const LABEL_MONO =
-  'font-[family-name:var(--jos-fonte-mono)] uppercase tracking-[1.5px] text-[11px] text-[var(--jos-cor-texto-suave)]'
+  'font-[family-name:var(--jos-fonte-mono)] uppercase tracking-[var(--jos-tracking-label)] text-[length:var(--jos-texto-micro)] text-[var(--jos-cor-texto-suave)]'
 
 /** Junta classes ignorando vazios — evita `class=" a  b"` com espaços duplos. */
 export function cx(...partes: ReadonlyArray<string | false | null | undefined>): string {

--- a/src/design/ui/base.ts
+++ b/src/design/ui/base.ts
@@ -1,0 +1,68 @@
+/**
+ * Vocabulário compartilhado dos controles (SPEC-DesignSystem-03a).
+ *
+ * A gramática visual vem do protótipo (tela de login e as 41 telas de `docs/design/`): campo e
+ * botão a **44px**, raio de card, borda neutra de baixo alfa, foco no acento, label pequena em
+ * mono UPPERCASE. Só três dos dezesseis componentes desta fatia têm tela de referência — o
+ * resto deriva desta gramática, em vez de inventar estética nova a cada arquivo.
+ *
+ * Mora aqui, e não em cada componente, porque "mesma forma de botão, mesmo vocabulário de
+ * formulário" é o que separa um design system de um punhado de componentes parecidos. Se a
+ * altura do `Input` e a do `Select` puderem divergir, um dia divergem.
+ */
+
+/**
+ * Altura única dos controles.
+ *
+ * 44px é o alvo de toque do WCAG 2.2 (AAA em 2.5.8) e é a altura do campo e do botão no
+ * protótipo. As densidades `comfortable`/`compact` foram **cortadas do MVP** (decisão do PI na
+ * F02) — por isso uma constante, não uma escala: uma escala aqui seria a densidade voltando
+ * pela porta lateral.
+ */
+export const ALTURA_CONTROLE = '44px'
+
+/** Altura do controle compacto embutido (ícone dentro de campo, dot de status). */
+export const ALTURA_INTERNA = '24px'
+
+/**
+ * Classes do anel de foco.
+ *
+ * `focus-visible` e não `focus`: o anel deve aparecer para quem navega por teclado e não a
+ * cada clique de mouse. A borda muda **junto** com o anel — quem enxerga pouco contraste de
+ * sombra ainda percebe a mudança de borda (PRD §14: foco visível e não encoberto).
+ */
+export const FOCO =
+  'outline-none focus-visible:border-[var(--jos-cor-acento)] focus-visible:shadow-[0_0_0_1px_var(--jos-cor-acento),0_0_18px_-8px_var(--jos-cor-acento)]'
+
+/** Borda neutra padrão — o RGB vem do tema, o alfa é do uso (README §2.6). */
+export const BORDA = 'border border-[rgba(var(--jos-borda-rgb),0.12)]'
+
+/** Superfície de campo/controle: levemente elevada sobre o fundo do app. */
+export const SUPERFICIE = 'bg-[var(--jos-cor-superficie-elevada)]'
+
+/**
+ * Transição padrão dos controles.
+ *
+ * Anima só `border-color`, `box-shadow`, `background-color` e `opacity` — nunca propriedade de
+ * layout. A duração vem do token, então `prefers-reduced-motion` a zera de uma vez (F02).
+ */
+export const TRANSICAO =
+  'transition-[border-color,box-shadow,background-color,opacity,transform] duration-[var(--jos-duracao-rapida)] ease-[var(--jos-curva-padrao)]'
+
+/**
+ * Estado desabilitado.
+ *
+ * Opacidade **e** cursor: opacidade sozinha comunica só a quem enxerga bem o contraste. O
+ * `aria-disabled`/`disabled` de cada componente é quem informa a tecnologia assistiva — a
+ * classe é o reforço visual, nunca a fonte da informação.
+ */
+export const DESABILITADO = 'disabled:opacity-45 disabled:cursor-not-allowed'
+
+/** Label pequena — README §3: mono UPPERCASE com tracking. */
+export const LABEL_MONO =
+  'font-[family-name:var(--jos-fonte-mono)] uppercase tracking-[1.5px] text-[11px] text-[var(--jos-cor-texto-suave)]'
+
+/** Junta classes ignorando vazios — evita `class=" a  b"` com espaços duplos. */
+export function cx(...partes: ReadonlyArray<string | false | null | undefined>): string {
+  return partes.filter(Boolean).join(' ')
+}

--- a/src/design/ui/base.ts
+++ b/src/design/ui/base.ts
@@ -14,7 +14,8 @@
 /**
  * Altura única dos controles.
  *
- * 44px é o alvo de toque do WCAG 2.2 (AAA em 2.5.8) e é a altura do campo e do botão no
+ * 44px é o alvo de toque do WCAG 2.2 SC 2.5.5 (AAA) — bem acima do mínimo AA de 24px
+ * (SC 2.5.8) — e é a altura do campo e do botão no
  * protótipo. As densidades `comfortable`/`compact` foram **cortadas do MVP** (decisão do PI na
  * F02) — por isso uma constante, não uma escala: uma escala aqui seria a densidade voltando
  * pela porta lateral.

--- a/src/design/ui/formularios.test.tsx
+++ b/src/design/ui/formularios.test.tsx
@@ -1,0 +1,340 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  Alternador,
+  Checkbox,
+  Combobox,
+  Field,
+  Input,
+  PasswordInput,
+  RadioGroup,
+  Select,
+  Slider,
+  Textarea
+} from './index'
+
+/**
+ * Formulários (SPEC-DesignSystem-03a, critérios 1–4 e 6; PRD §11.2).
+ *
+ * Consulta por papel, nunca por classe. O que se prova aqui é o que o leitor de tela recebe:
+ * nome, papel, estado, e a ligação entre o controle e as mensagens que o descrevem.
+ */
+
+const OPCOES = [
+  { valor: 'seo', rotulo: 'SEO' },
+  { valor: 'conteudo', rotulo: 'Conteúdo' },
+  { valor: 'operacoes', rotulo: 'Operações', desabilitada: true }
+] as const
+
+describe('Field: ligação entre controle e mensagens', () => {
+  it('o rótulo nomeia o controle', () => {
+    render(
+      <Field rotulo="Nome do workflow">
+        {(campo) => <Input {...campo} valor="" onMudar={vi.fn()} />}
+      </Field>
+    )
+    expect(screen.getByRole('textbox', { name: /nome do workflow/i })).toBeInTheDocument()
+  })
+
+  it('a descrição fica ligada por aria-describedby', () => {
+    render(
+      <Field rotulo="Nome" descricao="Use letras minúsculas e hífen.">
+        {(campo) => <Input {...campo} valor="" onMudar={vi.fn()} />}
+      </Field>
+    )
+    expect(screen.getByRole('textbox')).toHaveAccessibleDescription(/letras minúsculas e hífen/i)
+  })
+
+  it('obrigatório é anunciado por aria-required e por texto — não só pelo asterisco', () => {
+    // O `*` é convenção visual que nem todo usuário conhece, e não chega a leitor de tela.
+    render(
+      <Field rotulo="Nome" obrigatorio>
+        {(campo) => <Input {...campo} valor="" onMudar={vi.fn()} />}
+      </Field>
+    )
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-required', 'true')
+    expect(screen.getByText('(obrigatório)')).toBeInTheDocument()
+  })
+
+  describe('erro (critérios 2 e 4)', () => {
+    it('marca o controle como inválido e anuncia a mensagem', () => {
+      render(
+        <Field rotulo="Nome" erro="Nome já existe. Escolha outro ou edite o workflow atual.">
+          {(campo) => <Input {...campo} valor="x" onMudar={vi.fn()} />}
+        </Field>
+      )
+
+      const campo = screen.getByRole('textbox')
+      expect(campo).toHaveAttribute('aria-invalid', 'true')
+      // `role="alert"` faz a mensagem ser anunciada assim que aparece.
+      expect(screen.getByRole('alert')).toHaveTextContent(/nome já existe/i)
+      expect(campo).toHaveAccessibleDescription(/nome já existe/i)
+    })
+
+    it('a mensagem de erro traz problema E próxima ação (critério 4)', () => {
+      // A spec exige as duas metades. O componente não consegue forçá-las por tipo — quem
+      // escreve é o consumidor —, mas o DS não pode atrapalhar: a mensagem inteira é anunciada.
+      render(
+        <Field rotulo="Chave" erro="Chave inválida. Verifique o valor no painel do provedor.">
+          {(campo) => <Input {...campo} valor="" onMudar={vi.fn()} />}
+        </Field>
+      )
+      const alerta = screen.getByRole('alert')
+      expect(alerta).toHaveTextContent(/inválida/i) // problema
+      expect(alerta).toHaveTextContent(/verifique/i) // próxima ação
+    })
+
+    it('o erro substitui a descrição, para não competirem', () => {
+      render(
+        <Field rotulo="Nome" descricao="Texto de apoio" erro="Falhou. Tente de novo.">
+          {(campo) => <Input {...campo} valor="" onMudar={vi.fn()} />}
+        </Field>
+      )
+      expect(screen.queryByText('Texto de apoio')).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe('Input e variantes', () => {
+  it('digita e propaga o valor', async () => {
+    function Controlado(): React.JSX.Element {
+      const [v, setV] = useState('')
+      return (
+        <Field rotulo="Busca">{(campo) => <Input {...campo} valor={v} onMudar={setV} />}</Field>
+      )
+    }
+    render(<Controlado />)
+    await userEvent.type(screen.getByRole('textbox'), 'seo')
+    expect(screen.getByRole('textbox')).toHaveValue('seo')
+  })
+
+  it('Textarea aceita várias linhas', async () => {
+    function Controlado(): React.JSX.Element {
+      const [v, setV] = useState('')
+      return (
+        <Field rotulo="Notas">{(campo) => <Textarea {...campo} valor={v} onMudar={setV} />}</Field>
+      )
+    }
+    render(<Controlado />)
+    const area = screen.getByRole('textbox', { name: /notas/i })
+    await userEvent.type(area, 'linha 1{Enter}linha 2')
+    expect(area).toHaveValue('linha 1\nlinha 2')
+  })
+
+  describe('PasswordInput', () => {
+    it('nasce oculto e o botão de revelar é operável por teclado', async () => {
+      render(
+        <Field rotulo="Senha">
+          {(campo) => <PasswordInput {...campo} valor="segredo" onMudar={vi.fn()} />}
+        </Field>
+      )
+
+      // Campo de senha não tem papel `textbox` — é justamente o que o esconde do leitor.
+      const revelar = screen.getByRole('button', { name: 'Mostrar senha' })
+      expect(revelar).toHaveAttribute('aria-pressed', 'false')
+
+      await userEvent.click(revelar)
+      // O rótulo muda junto com o estado: quem usa leitor de tela sabe o que aconteceu.
+      expect(screen.getByRole('button', { name: 'Ocultar senha' })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      )
+      expect(screen.getByRole('textbox', { name: /senha/i })).toHaveValue('segredo')
+    })
+  })
+})
+
+describe('Select (Radix encapsulado — critério 3)', () => {
+  it('expõe papel de combobox com o rótulo do Field', () => {
+    render(
+      <Field rotulo="Especialidade">
+        {(campo) => <Select {...campo} valor="" onMudar={vi.fn()} opcoes={OPCOES} />}
+      </Field>
+    )
+    expect(screen.getByRole('combobox', { name: /especialidade/i })).toBeInTheDocument()
+  })
+
+  it('abre por teclado e escolhe uma opção', async () => {
+    const onMudar = vi.fn()
+    render(
+      <Field rotulo="Especialidade">
+        {(campo) => <Select {...campo} valor="" onMudar={onMudar} opcoes={OPCOES} />}
+      </Field>
+    )
+
+    const gatilho = screen.getByRole('combobox')
+    gatilho.focus()
+    await userEvent.keyboard('{Enter}')
+
+    const opcao = await screen.findByRole('option', { name: 'SEO' })
+    await userEvent.click(opcao)
+    expect(onMudar).toHaveBeenCalledWith('seo')
+  })
+})
+
+describe('Combobox', () => {
+  it('implementa o padrão ARIA combobox', () => {
+    render(
+      <Field rotulo="Skill">
+        {(campo) => <Combobox {...campo} valor="" onMudar={vi.fn()} opcoes={OPCOES} />}
+      </Field>
+    )
+    const entrada = screen.getByRole('combobox', { name: /skill/i })
+    expect(entrada).toHaveAttribute('aria-expanded', 'false')
+    expect(entrada).toHaveAttribute('aria-autocomplete', 'list')
+  })
+
+  it('filtra pela busca e escolhe com Enter', async () => {
+    const onMudar = vi.fn()
+    render(
+      <Field rotulo="Skill">
+        {(campo) => <Combobox {...campo} valor="" onMudar={onMudar} opcoes={OPCOES} />}
+      </Field>
+    )
+
+    const entrada = screen.getByRole('combobox')
+    await userEvent.type(entrada, 'cont')
+    expect(screen.getByRole('option', { name: 'Conteúdo' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'SEO' })).not.toBeInTheDocument()
+
+    await userEvent.keyboard('{Enter}')
+    expect(onMudar).toHaveBeenCalledWith('conteudo')
+  })
+
+  it('busca sem resultado ensina, em vez de dizer "vazio"', async () => {
+    render(
+      <Field rotulo="Skill">
+        {(campo) => <Combobox {...campo} valor="" onMudar={vi.fn()} opcoes={OPCOES} />}
+      </Field>
+    )
+    await userEvent.type(screen.getByRole('combobox'), 'zzzz')
+    expect(screen.getByText(/nenhuma opção corresponde/i)).toBeInTheDocument()
+  })
+
+  it('Escape fecha sem alterar o valor', async () => {
+    const onMudar = vi.fn()
+    render(
+      <Field rotulo="Skill">
+        {(campo) => <Combobox {...campo} valor="seo" onMudar={onMudar} opcoes={OPCOES} />}
+      </Field>
+    )
+    const entrada = screen.getByRole('combobox')
+    await userEvent.click(entrada)
+    await userEvent.keyboard('{Escape}')
+    // Cancelar tem de ser sempre reversível.
+    expect(onMudar).not.toHaveBeenCalled()
+  })
+})
+
+describe('Checkbox, RadioGroup, Switch e Slider', () => {
+  it('Checkbox alterna por teclado', async () => {
+    const onMudar = vi.fn()
+    render(<Checkbox rotulo="Exigir aprovação" marcado={false} onMudar={onMudar} />)
+
+    const caixa = screen.getByRole('checkbox', { name: 'Exigir aprovação' })
+    caixa.focus()
+    await userEvent.keyboard(' ')
+    expect(onMudar).toHaveBeenCalledWith(true)
+  })
+
+  it('Checkbox indeterminado é anunciado como mixed, não como falso', () => {
+    // "Nem tudo, nem nada" é um terceiro estado — reduzi-lo a `false` mentiria sobre a seleção.
+    render(<Checkbox rotulo="Todos" marcado="indeterminado" onMudar={vi.fn()} />)
+    expect(screen.getByRole('checkbox', { name: 'Todos' })).toHaveAttribute('aria-checked', 'mixed')
+  })
+
+  it('o rótulo do Checkbox é clicável — amplia o alvo além dos 20px da caixa', async () => {
+    const onMudar = vi.fn()
+    render(<Checkbox rotulo="Exigir aprovação" marcado={false} onMudar={onMudar} />)
+    await userEvent.click(screen.getByText('Exigir aprovação'))
+    expect(onMudar).toHaveBeenCalledWith(true)
+  })
+
+  it('RadioGroup expõe as opções e navega por setas', async () => {
+    const onMudar = vi.fn()
+    render(
+      <RadioGroup
+        rotulo="Tipo de execução"
+        valor="seo"
+        onMudar={onMudar}
+        opcoes={[
+          { valor: 'seo', rotulo: 'Sequencial' },
+          { valor: 'conteudo', rotulo: 'Paralelo' }
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('radiogroup', { name: 'Tipo de execução' })).toBeInTheDocument()
+
+    // A opção ativa é anunciada por `aria-checked` — não por cor de preenchimento.
+    expect(screen.getByRole('radio', { name: 'Sequencial' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    )
+    expect(screen.getByRole('radio', { name: 'Paralelo' })).toHaveAttribute('aria-checked', 'false')
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Paralelo' }))
+    expect(onMudar).toHaveBeenCalledWith('conteudo')
+  })
+
+  /*
+   * Navegação por seta no RadioGroup: **não verificável em jsdom**.
+   *
+   * O Radix implementa roving tabindex — o grupo carrega `tabindex=0`, os itens ficam em `-1`,
+   * e o movimento por seta depende de `focus()` real do navegador somado a medidas de layout
+   * que o jsdom não calcula. Diagnosticado: o clique dispara `onMudar`, a seta não, nem depois
+   * de o item receber foco.
+   *
+   * Registrar aqui é mais honesto que escrever um teste que passa mascarando o que não foi
+   * medido — e mais honesto que apagar a preocupação. A navegação por teclado do RadioGroup é
+   * garantida pelo Radix (WAI-ARIA APG) e será exercitada no E2E das telas que o usarem
+   * (F04a/F04b), onde há navegador de verdade.
+   */
+  it.todo('RadioGroup navega por setas — cobrir no E2E, jsdom não move o foco do Radix')
+
+  it('Switch expõe papel e estado', async () => {
+    const onMudar = vi.fn()
+    render(<Alternador rotulo="Modo autônomo" ligado={false} onMudar={onMudar} />)
+
+    const chave = screen.getByRole('switch', { name: 'Modo autônomo' })
+    expect(chave).toHaveAttribute('aria-checked', 'false')
+    await userEvent.click(chave)
+    expect(onMudar).toHaveBeenCalledWith(true)
+  })
+
+  it('Slider anuncia o valor formatado e responde ao teclado', async () => {
+    const onMudar = vi.fn()
+    render(<Slider rotulo="Limite diário" valor={40} onMudar={onMudar} formatar={(v) => `${v}%`} />)
+
+    const faixa = screen.getByRole('slider', { name: 'Limite diário' })
+    // `aria-valuetext` leva a versão legível: "40" sozinho não diz que é porcentagem.
+    expect(faixa).toHaveAttribute('aria-valuetext', '40%')
+    faixa.focus()
+    await userEvent.keyboard('{ArrowRight}')
+    expect(onMudar).toHaveBeenCalledWith(41)
+  })
+
+  it('o valor do Slider também aparece em texto — posição de alça não é número', () => {
+    render(<Slider rotulo="Limite" valor={40} onMudar={vi.fn()} formatar={(v) => `${v}%`} />)
+    expect(screen.getByText('40%')).toBeInTheDocument()
+  })
+})
+
+describe('estado desabilitado em toda a família', () => {
+  it.each([
+    ['Input', <Input key="i" valor="" onMudar={vi.fn()} desabilitado />],
+    ['Textarea', <Textarea key="t" valor="" onMudar={vi.fn()} desabilitado />]
+  ])('%s desabilitado é anunciado como tal', (_nome, elemento) => {
+    render(<Field rotulo="Campo">{() => elemento}</Field>)
+    expect(screen.getByRole('textbox')).toBeDisabled()
+  })
+
+  it('Checkbox desabilitado não alterna', async () => {
+    const onMudar = vi.fn()
+    render(<Checkbox rotulo="Trava" marcado={false} onMudar={onMudar} desabilitado />)
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Trava' }))
+    expect(onMudar).not.toHaveBeenCalled()
+  })
+})

--- a/src/design/ui/index.ts
+++ b/src/design/ui/index.ts
@@ -1,11 +1,25 @@
 /**
- * Camada `ui` do design system (SPEC-DesignSystem-01).
+ * Camada `ui` do design system (SPEC-DesignSystem-01 e 03a).
  *
  * Componentes de base, sem conhecimento de domínio. Depende de `tokens` + Radix + Lucide;
  * **nada** acima dela (patterns) nem fora do DS (produto, Supabase, Electron main).
  *
  * Este barril é a **superfície pública da camada**: quem consome importa daqui, e é o que
- * mantém o Radix encapsulado — reexportar o primitivo aqui anularia o encapsulamento.
+ * mantém o Radix encapsulado — reexportar um primitivo aqui anularia o encapsulamento.
  */
 
+export { ALTURA_CONTROLE } from './base'
+
+// Ações (PRD §11.1)
+export { Button } from './Button'
+export { IconButton } from './IconButton'
+export { ButtonGroup } from './ButtonGroup'
+export { Link } from './Link'
+
+// Formulários (PRD §11.2)
+export { Field, FormMessage, type AtributosDoControle } from './Field'
+export { Input, PasswordInput, Textarea } from './Input'
+export { Select, type OpcaoSelect } from './Select'
+export { Combobox } from './Combobox'
+export { Checkbox, RadioGroup, Slider, type OpcaoRadio } from './Controles'
 export { Alternador } from './Alternador'

--- a/src/renderer/tests/setup-tela.ts
+++ b/src/renderer/tests/setup-tela.ts
@@ -10,6 +10,29 @@ beforeAll(async () => {
   await initI18n('pt-BR')
 })
 
+/*
+ * Lacunas do jsdom que os primitivos Radix exigem (SPEC-DesignSystem-03a).
+ *
+ * `ResizeObserver` e `scrollIntoView` existem em todo navegador real, mas não no jsdom. Sem
+ * eles, `Slider` e `Select` quebram na montagem — falha de **ambiente**, não do componente.
+ *
+ * Os stubs são deliberadamente inertes: eles destravam a montagem sem simular comportamento
+ * que não existe. Um `ResizeObserver` que inventasse medidas faria o teste afirmar sobre
+ * dimensões que o jsdom não calcula — daria confiança falsa. Layout e rolagem se verificam no
+ * screenshot do Playwright, que roda num navegador de verdade.
+ */
+if (!('ResizeObserver' in globalThis)) {
+  globalThis.ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+}
+
+if (typeof Element !== 'undefined' && Element.prototype.scrollIntoView === undefined) {
+  Element.prototype.scrollIntoView = function scrollIntoView(): void {}
+}
+
 afterEach(() => {
   cleanup()
 })

--- a/tests/prova/controles.prova.ts
+++ b/tests/prova/controles.prova.ts
@@ -1,0 +1,148 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Prova visual dos controles (SPEC-DesignSystem-03a).
+ *
+ * Roda num **navegador de verdade** — é o que jsdom não faz. O que se verifica aqui não é o
+ * papel ARIA (isso os testes de componente já cobrem), e sim o que só existe quando há layout:
+ * altura real dos controles, contraste **computado**, fontes carregadas, anel de foco pintado.
+ *
+ * Não é regressão visual por baseline: comparar PNG exigiria commitar imagens e conviver com
+ * falso vermelho por antialiasing entre máquinas — e regressão visual está suspensa no MVP-003
+ * §4. As capturas são **artefato de revisão**; as asserções são medidas, não pixels.
+ */
+
+const ROTA = (params: string): string => `/?${params}`
+
+/** As quatro combinações que a fatia precisa mostrar. */
+const CENARIOS = [
+  { nome: 'jarvis-escuro', query: 'modo=dark&modulo=jarvis' },
+  { nome: 'jarvis-claro', query: 'modo=light&modulo=jarvis' },
+  { nome: 'noa-escuro', query: 'modo=dark&modulo=noa' },
+  { nome: 'noa-claro', query: 'modo=light&modulo=noa' }
+] as const
+
+test.describe('galeria de controles', () => {
+  for (const cenario of CENARIOS) {
+    test(`captura ${cenario.nome}`, async ({ page }) => {
+      await page.goto(ROTA(cenario.query))
+      await page.waitForSelector('[data-testid="galeria"]')
+      // As fontes locais precisam ter carregado antes da captura, senão a imagem registra a
+      // fonte de sistema e a prova de tipografia não vale nada.
+      await page.evaluate(() => document.fonts.ready)
+
+      await expect(page.locator('[data-testid="galeria"]')).toBeVisible()
+      await page.screenshot({
+        path: `reports/prova/${cenario.nome}.png`,
+        fullPage: true
+      })
+    })
+  }
+
+  test('a família inteira alinha na mesma altura (44px)', async ({ page }) => {
+    // A decisão do PI foi altura única. É o tipo de invariante que se desfaz calado: alguém
+    // ajusta o padding de um componente e ele passa a destoar por 2px numa linha de formulário.
+    await page.goto(ROTA('modo=dark'))
+    await page.waitForSelector('[data-testid="galeria"]')
+
+    const medidas = await page.evaluate(() => {
+      // Só os controles de **linha de formulário**: botão de texto, campo de texto e senha,
+      // gatilho de select e combobox. Checkbox, radio e switch têm caixa própria
+      // (`--jos-tamanho-marcador`, 20px) e o alvo clicável deles é o rótulo — medi-los aqui
+      // compararia papéis diferentes. Textarea cresce por `rows`, por desenho.
+      const eDeLinha = (el: HTMLElement): boolean => {
+        if (el.tagName === 'INPUT') {
+          const tipo = el.getAttribute('type')
+          return tipo === 'text' || tipo === 'password'
+        }
+        if (el.tagName === 'BUTTON') {
+          // Fora: IconButton (quadrado, tem aria-label) e os primitivos Radix, que carregam
+          // `role` próprio (checkbox, radio, switch).
+          return el.getAttribute('aria-label') === null && el.getAttribute('role') === null
+        }
+        return false
+      }
+
+      return [...document.querySelectorAll<HTMLElement>('button, input')]
+        .filter((el) => el.offsetHeight > 0 && eDeLinha(el))
+        .map((el) => ({
+          descricao: `${el.tagName}[${el.getAttribute('type') ?? '-'}]`,
+          altura: el.offsetHeight
+        }))
+    })
+
+    expect(medidas.length).toBeGreaterThan(5)
+    for (const { descricao, altura } of medidas) {
+      expect(altura, `${descricao} deveria alinhar em 44px`).toBe(44)
+    }
+  })
+
+  test('o texto do corpo atinge 4.5:1 nos dois modos (WCAG 2.2 AA)', async ({ page }) => {
+    // Contraste **computado** pelo navegador, não o valor que o token declara: é aqui que se
+    // pega uma variável que não resolveu e caiu para a cor herdada.
+    for (const modo of ['dark', 'light']) {
+      await page.goto(ROTA(`modo=${modo}`))
+      await page.waitForSelector('[data-testid="galeria"]')
+
+      const razao = await page.evaluate(() => {
+        const galeria = document.querySelector('[data-testid="galeria"]') as HTMLElement
+        const estilo = getComputedStyle(galeria)
+
+        const canais = (cor: string): number[] => {
+          const m = cor.match(/\d+(\.\d+)?/g)
+          if (m === null) throw new Error(`Cor não interpretável: ${cor}`)
+          return m.slice(0, 3).map(Number)
+        }
+        const lum = (cor: string): number => {
+          const [r, g, b] = canais(cor).map((c) => {
+            const s = c / 255
+            return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+          })
+          return 0.2126 * r + 0.7152 * g + 0.0722 * b
+        }
+
+        const a = lum(estilo.color)
+        const b = lum(estilo.backgroundColor)
+        const [claro, escuro] = a > b ? [a, b] : [b, a]
+        return (claro + 0.05) / (escuro + 0.05)
+      })
+
+      expect(razao, `contraste do corpo no modo ${modo}`).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  test('as fontes do protótipo carregam — não a fonte de sistema', async ({ page }) => {
+    // Se o `@font-face` apontasse para caminho errado, a UI cairia em `sans-serif` sem nada
+    // falhar. Só um navegador de verdade responde isso.
+    await page.goto(ROTA('modo=dark'))
+    await page.evaluate(() => document.fonts.ready)
+
+    const carregadas = await page.evaluate(() => {
+      const nomes = new Set<string>()
+      document.fonts.forEach((f) => {
+        if (f.status === 'loaded') nomes.add(f.family)
+      })
+      return [...nomes]
+    })
+
+    expect(carregadas).toContain('Michroma')
+    expect(carregadas).toContain('Rajdhani')
+    expect(carregadas).toContain('Share Tech Mono')
+  })
+
+  test('o anel de foco é pintado ao navegar por teclado', async ({ page }) => {
+    // Foco visível é critério de aceite (PRD §14) e é invisível em jsdom: só existe pintado.
+    await page.goto(ROTA('modo=dark'))
+    await page.waitForSelector('[data-testid="galeria"]')
+
+    await page.keyboard.press('Tab')
+    const sombra = await page.evaluate(() => {
+      const ativo = document.activeElement as HTMLElement | null
+      if (ativo === null || ativo === document.body) return null
+      return getComputedStyle(ativo).boxShadow
+    })
+
+    expect(sombra, 'o elemento focado tem anel visível').not.toBe('none')
+    expect(sombra).not.toBeNull()
+  })
+})

--- a/vite.prova.config.ts
+++ b/vite.prova.config.ts
@@ -1,0 +1,36 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+/**
+ * Servidor da galeria de prova (SPEC-DesignSystem-03a).
+ *
+ * Mora na **raiz**, e não em `src/design/prova/`, porque a fronteira do DS (Fatia 01) proíbe
+ * importar `node:*` de dentro de `src/design/` — e um config de build precisa de `node:path`.
+ * A regra está certa: este arquivo é ferramental de build, não código de runtime do design
+ * system. Quem se move é o arquivo, não a regra.
+ *
+ * Config **separado** do `electron.vite.config.ts` de propósito: a galeria não é parte do app.
+ * Misturá-la ao renderer arrastaria uma rota de teste para dentro do bundle de produção, e a
+ * primeira coisa que alguém faria seria protegê-la com um `if (import.meta.env.DEV)` — que é
+ * exatamente o tipo de condicional que um dia falha do lado errado.
+ *
+ * Porta 5181: a 5180 é do app (`strictPort`, CLAUDE.md). Aqui também `strictPort` — se a porta
+ * estiver ocupada, é melhor falhar do que capturar a tela de outro processo.
+ */
+export default defineConfig({
+  root: resolve(__dirname, 'src/design/prova'),
+  plugins: [react(), tailwindcss()],
+  server: {
+    port: 5181,
+    strictPort: true,
+    // `127.0.0.1` explícito: no Windows, `localhost` pode resolver para `::1` (IPv6) enquanto
+    // o Playwright sonda o endereço IPv4 — o servidor sobe e o `webServer` expira mesmo assim.
+    host: '127.0.0.1'
+  },
+  build: {
+    outDir: resolve(__dirname, 'out/prova'),
+    emptyOutDir: true
+  }
+})


### PR DESCRIPTION
Os 16 componentes de ação e formulário (PRD §11.1/§11.2), sobre os tokens da F02 e os primitivos Radix da F01.

Spec: `docs/spec/spec-design-system-03a-componentes-acoes-forms.md` (`aprovada-pi`, 2026-07-21).

refs #19

## O que entra

| Grupo | Componentes |
|---|---|
| Ações | `Button` (primária/secundária/perigo), `IconButton`, `ButtonGroup`, `Link` |
| Campos | `Field`, `FormMessage`, `Input`, `PasswordInput`, `Textarea` |
| Radix | `Select`, `Checkbox`, `RadioGroup`, `Slider`, `Alternador` (Switch) |
| Próprio | `Combobox` — padrão ARIA completo; o Radix não publica um |

Mais: `ui/base.ts` (vocabulário compartilhado), a galeria de prova visual e a regra de lint do critério 5.

## Critérios de aceite

| # | Critério | Onde |
|---|---|---|
| 1 | Teclado + papel/estado corretos | `acoes.test.tsx`, `formularios.test.tsx` |
| 2 | Texto/ícone além de cor | idem — e agora também **entre variantes** (ver decisão 2) |
| 3 | Radix não vaza a API | superfície própria em todos |
| 4 | Erro com problema **e** próxima ação | `formularios.test.tsx` |
| 5 | Só tokens | regra ESLint + verificada por mutação |
| 6 | Fronteira verde | lint passa |
| 7 | `test`/`lint` + relatório | `reports/TESTS.md` |

## Decisões técnicas

**1. A gramática visual foi derivada, não inventada.** Só **3 dos 16** componentes têm tela de referência no protótipo (Input, Button primário, Button secundário — da tela de login). Decisão do PI: extrair o vocabulário do que existe — 44px, raio de card, borda de baixo alfa, label mono UPPERCASE, foco no acento — e concentrá-lo em `ui/base.ts`. Sem isso seriam 16 dialetos.

**2. A hierarquia de ação passou a ser preenchimento, não matiz.** A primeira versão distinguia as variantes só por cor. Com `#C4C4C4` (default do NOA) ou `#FFFFE3` — ambos na paleta de 8 —, primária, carregando e desabilitado renderizavam como o **mesmo botão cinza**. O sistema aplicava "estado nunca só por cor" dentro de cada componente e violava a regra uma camada acima. Agora primária é sólida e pesada; perigo, contornada e pesada.

**3. As semânticas ganharam variante de leitura.** Como texto no modo claro, as cinco falhavam 4.5:1 — `err` 2.53:1, `info` 1.54:1. A cor de marca segue intacta em borda, ícone e preenchimento; só o texto lê da variante ajustada. Mesmo mecanismo que o acento já usava.

**4. `textMuted` corrigido: `#6b7382` → `#757d8c`.** Media 4.08–4.12:1 no escuro e não é decorativo — carrega placeholders, texto de apoio e **todas as labels** (em micro com uppercase, texto pequeno sem isenção). O desvio é o mínimo que atinge a régua: fidelidade cede à legibilidade (PRODUCT.md princípio 1).

**5. `Field` devolve os atributos ARIA por render prop.** Cada componente montar o próprio `aria-describedby` é a via para um esquecer. Erro precede descrição na ordem de leitura: quem acabou de errar ouve o problema antes da instrução genérica.

**6. `IconButton.rotulo` é obrigatório e sem default.** Botão de ícone sem nome acessível vira erro de compilação, não achado de auditoria.

**7. `ButtonGroup papel="segmentado"` foi removido.** Prometia `role="radiogroup"` sobre filhos `<button>` — o leitor anunciaria grupo de rádio **sem rádios dentro**, pior que a fileira que tentava corrigir. O controle segmentado de verdade precisa de estado e navegação por setas: escopo da F04a.

**8. `Combobox` fecha por `focusout`, não por timer.** A versão inicial usava `setTimeout(…, 120)`: race sob quadro lento e timer disparando após o unmount. `relatedTarget` responde a pergunta certa sem constante para calibrar.

## Como isto foi verificado

Três camadas, cada uma pegando o que a anterior não pega:

**Testes de papel (91)** — `getByRole`, nunca classe. Pegaram um bug real: `aria-label` estava no `Root` do slider, mas quem carrega `role="slider"` é o `Thumb` — a faixa ficava anônima.

**Prova visual (8)** — galeria num Chromium de verdade. Pegou **dois defeitos com os 91 testes verdes**: o CSS dos componentes não estava sendo gerado (Tailwind não varria `../ui`), e o card do NOA estava invertido (`nt16` é cor de texto, não superfície — os índices `jt`/`nt` são independentes).

**`/impeccable critique`** — duas avaliações isoladas. Detector limpo, Nielsen 32/40, AI slop negativo. Achou os 10 itens de contraste e hierarquia acima, todos verificados por mim antes de corrigir.

Cada correção deixou teste que a trava. Verificado por mutação: restaurando `#6b7382`, 2 ficam vermelhos; removendo o bloco da regra de lint, 3.

## Plano de teste

- [x] `npm run typecheck` verde
- [x] `npm run lint` verde
- [x] `npm test` — **411 passando**, 1 `todo` documentado
- [x] `npm run test:prova` — 8 provas visuais
- [x] Mutação: tokens, contraste, encapsulamento e fronteira
- [ ] Relatório carimbado — próximo commit

## Registrado, não silenciado

- **`RadioGroup` por setas não é verificável em jsdom** — o roving tabindex do Radix depende de foco real. Deixei `it.todo` com a razão escrita, em vez de um teste que passa medindo outra coisa. Cobre-se no E2E da F04a.
- **A galeria cobre 4 de 32 combinações** de acento (8 × 2 modos × 2 módulos). Os dois defeitos apareceram justamente nos defaults. Ampliar a matriz é candidato para a F06.
- **`:active` não existe em nenhum dos 16** — nenhum controle dá feedback de pressão. Fora do escopo desta fatia; anotado para a F06 (hardening).
- **Card [#41](https://github.com/RodReis/rrb-jarvisOS/issues/41)** aberto: o renderer sobe em porta variável, contra o `strictPort` do CLAUDE.md. Achado ao subir o app; não misturei na fatia.