### PR TITLE
fix: carregar o .env no processo main

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -96,6 +96,14 @@ Status: **entregue** — spec `aprovada-pi` (2026-07-21, emendada em 2026-07-22)
 3. **`userId` virou função em `WorkspaceService` e nos handlers IPC** — a identidade deixou de ser fixa (local antes do login, sessão depois). Capturar a string no boot congelaria o escopo da auditoria no usuário local para sempre.
 4. **Teardown do E2E usa `app.exit()`, não `close()` nem `quit()`** — os dois travam, por comportamento correto do produto: o app vive no tray (`window-all-closed` vazio, SPEC-02) e os timers de rotação do `winston-daily-rotate-file` seguram o event loop no `will-quit`. Registrado em `docs/TESTING.md`.
 
+**Correção posterior — [#43](https://github.com/RodReis/rrb-jarvisOS/issues/43) (2026-07-23): o `.env` nunca era lido.**
+
+A fatia foi dada como entregue com o login funcionando, mas o app **não carregava o arquivo `.env`**: `readSupabaseConfig()` lê `process.env` cru e `dotenv` não existia no repo. O login funcionou no dia da entrega porque as variáveis estavam exportadas no shell daquela sessão — o arquivo em disco nunca foi exercitado. Quem clonasse o repo e seguisse o `.env.example` receberia "credenciais ausentes" com o arquivo corretamente preenchido, sem nenhum sinal de que ele fora ignorado.
+
+A lição não é sobre `dotenv`. É que **"funcionou na minha máquina" e "funciona a partir do repo" eram estados indistinguíveis** — nenhum teste cobria o caminho do arquivo, e o comportamento correto de degradação graciosa (sem credencial ⇒ só o login indisponível) mascarava o defeito: o app exibia exatamente a mesma tela de quem nunca configurou nada. Um defeito que se disfarça do estado esperado não aparece sozinho; só aparece quando alguém roda o caminho limpo. Corrigido em `src/main/env.ts` com precedência **ambiente vence arquivo** (o CI segue injetando os próprios valores) e provado no app real com as quatro variáveis removidas do shell.
+
+Junto dele, dois fatos da fatia foram vistos rodando pela primeira vez fora do teste: os tokens gravados cifrados no cofre (DPAPI) e a sessão de 30 dias (`expiresAt` a 30 dias do login, ADR-001 §2).
+
 ### Fatia 04 — Modelo de dados mínimo + AuditEvent stub (`docs/spec/spec-fundacao-04-dados-audit.md`)
 
 Status: **entregue** — spec `aprovada-pi` (2026-07-21, emendada em 2026-07-22); issue #5; PR [#28](https://github.com/RodReis/rrb-jarvisOS/pull/28). Sustenta 02 (entregue junto) e 03 (bloqueada).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -10,10 +10,13 @@ Atualizado em: **2026-07-23**. Mantido pelo Code a cada entrega (junto com `DEVE
 |---|---|---|---|---|
 | [#34](https://github.com/RodReis/rrb-jarvisOS/issues/34) | — (`[INFRA]`) | — | *(sem spec — infra)* | — |
 | [#41](https://github.com/RodReis/rrb-jarvisOS/issues/41) | — (`[FIX]`) | MVP-001 | *(sem spec — bug documentado)* | — |
+| [#43](https://github.com/RodReis/rrb-jarvisOS/issues/43) | — (`[FIX]`) | MVP-001 | *(sem spec — fonte: `.env.example` §1-8 + SPEC-Fundacao-03)* | — |
 
 > **`proplan:next` = [#20](https://github.com/RodReis/rrb-jarvisOS/issues/20)** (MVP-003 · F03b Componentes: dados + overlays + feedback). F01, F02 e F03a entregues em 2026-07-23. Pela ordem do épico, F03b e F05 podem correr em paralelo.
 
 > Card **[#34](https://github.com/RodReis/rrb-jarvisOS/issues/34)** (`[INFRA]`, Backlog): separar o E2E em job de CI próprio, condicional por paths. Criado pelo Code durante a F03 — o cache do Electron (parte fácil) já saiu no PR #35; a separação do E2E do relatório é infra maior e vai em PR dedicado.
+
+> Card **[#43](https://github.com/RodReis/rrb-jarvisOS/issues/43)** (`[FIX]`, 2026-07-23): **o app nunca lia o arquivo `.env`** — `dotenv` não existia no repo e `readSupabaseConfig()` consulta `process.env` cru. O login da SPEC-Fundacao-03 só funcionava com as variáveis exportadas no shell; a partir do repo, dava "credenciais ausentes" com o arquivo preenchido. Achado ao subir o app durante a F03b; corrigido em branch próprio (`fix/carregar-env-no-main`), **sem misturar na fatia**. Provado no app real com o shell limpo: login concluído, tokens cifrados no cofre, sessão de 30 dias. Detalhe no `DEVELOPMENT.md` § Fatia 03.
 
 > A Fatia 06 saiu como **#8** (o número 7 já estava ocupado). Sub-issue do épico #1; assignee PI.
 

--- a/reports/TESTS.md
+++ b/reports/TESTS.md
@@ -13,7 +13,7 @@ Totais da última execução (regenerado, não acumulado):
 | Data | Issue | SPEC | Categoria | Testes | Pass | Falha | Cobertura % | PR | Link PR |
 |------|-------|------|-----------|-------:|-----:|------:|------------:|----:|--------|
 | — | — | — | Regras de Negócio | 203 | 203 | 0 | 78.2 | — | — |
-| — | — | — | Banco | 117 | 117 | 0 | 87.5 | — | — |
+| — | — | — | Banco | 132 | 132 | 0 | 85.5 | — | — |
 | — | — | — | Tela | 95 | 94 | 0 | 89.6 | — | — |
 
 ## Histórico por entrega
@@ -64,3 +64,6 @@ Append-only — linhas de entregas passadas são imutáveis.
 | 2026-07-23 | #19 | spec-design-system-03a-componentes-acoes-forms | Regras de Negócio | 203 | 203 | 0 | 78.2 | #42 | [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42) |
 | 2026-07-23 | #19 | spec-design-system-03a-componentes-acoes-forms | Banco | 117 | 117 | 0 | 87.5 | #42 | [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42) |
 | 2026-07-23 | #19 | spec-design-system-03a-componentes-acoes-forms | Tela | 95 | 94 | 0 | 89.6 | #42 | [#42](https://github.com/RodReis/rrb-jarvisOS/pull/42) |
+| 2026-07-23 | #43 | — | Regras de Negócio | 203 | 203 | 0 | 78.2 | #44 | [#44](https://github.com/RodReis/rrb-jarvisOS/pull/44) |
+| 2026-07-23 | #43 | — | Banco | 132 | 132 | 0 | 85.5 | #44 | [#44](https://github.com/RodReis/rrb-jarvisOS/pull/44) |
+| 2026-07-23 | #43 | — | Tela | 95 | 94 | 0 | 89.6 | #44 | [#44](https://github.com/RodReis/rrb-jarvisOS/pull/44) |

--- a/src/main/env.int-spec.ts
+++ b/src/main/env.int-spec.ts
@@ -1,0 +1,183 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { carregarEnv, parseEnv } from './env'
+import { readSupabaseConfig } from './auth/supabase-client'
+
+/**
+ * Carga do `.env` (FIX #43).
+ *
+ * Categoria **Banco**: `carregarEnv` lê disco. A régua da categoria é "integração com storage
+ * local", como registrado na F06 do MVP-001 — não é sobre SQLite.
+ *
+ * O teste que importa é o último: `.env` no disco ⇒ `readSupabaseConfig()` devolve config. É a
+ * ligação que faltava e que nenhuma peça isolada provava — cada uma delas estava correta, e o
+ * app mesmo assim dizia "credenciais ausentes".
+ */
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'jos-env-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+/** Escreve um `.env` no diretório temporário e devolve o caminho. */
+function escrever(conteudo: string): string {
+  const caminho = join(dir, '.env')
+  writeFileSync(caminho, conteudo, 'utf8')
+  return caminho
+}
+
+describe('parseEnv', () => {
+  it('lê pares, ignorando comentários e linhas vazias', () => {
+    expect(
+      parseEnv(['# comentário', '', 'A=1', '  B=2  ', '', '# outro', 'C=3'].join('\n'))
+    ).toEqual({ A: '1', B: '2', C: '3' })
+  })
+
+  it('remove aspas envolventes, mas preserva as internas', () => {
+    expect(parseEnv('A="valor"\nB=\'outro\'\nC="meio"fim"')).toEqual({
+      A: 'valor',
+      B: 'outro',
+      // Abre com aspa e fecha com aspa, mas o conteúdo tem aspas no meio — o corte de
+      // delimitador continua sendo só o primeiro e o último caractere.
+      C: 'meio"fim'
+    })
+  })
+
+  it('preserva `=` e `#` dentro do valor', () => {
+    // Chave em base64 termina em `=`, e `#` aparece em cor hex. Cortar no primeiro `=` ou
+    // tratar `#` como comentário no meio da linha truncaria credencial em silêncio — o valor
+    // ficaria *quase* certo, que é a pior forma de errar.
+    expect(parseEnv('KEY=abc==\nCOR=#FF5C00\nURL=https://x.co/a?b=c')).toEqual({
+      KEY: 'abc==',
+      COR: '#FF5C00',
+      URL: 'https://x.co/a?b=c'
+    })
+  })
+
+  it('descarta linha sem `=` e chave vazia em vez de inventar entrada', () => {
+    expect(parseEnv('lixo\n=semchave\nA=1')).toEqual({ A: '1' })
+  })
+
+  it('aceita valor vazio — a chave existe e está em branco', () => {
+    // Distinto de ausente: `SUPABASE_URL=` declara a variável sem valor, e quem consome
+    // (`readSupabaseConfig`) trata o vazio como não configurado. O parser não decide isso.
+    expect(parseEnv('A=')).toEqual({ A: '' })
+  })
+})
+
+describe('carregarEnv (critério 1)', () => {
+  it('aplica ao ambiente as chaves do arquivo', () => {
+    const env: NodeJS.ProcessEnv = {}
+    const aplicadas = carregarEnv(escrever('SUPABASE_URL=https://x.supabase.co\nOUTRA=2'), env)
+
+    expect(env.SUPABASE_URL).toBe('https://x.supabase.co')
+    expect(env.OUTRA).toBe('2')
+    expect(aplicadas).toEqual(['SUPABASE_URL', 'OUTRA'])
+  })
+
+  it('devolve os **nomes** das chaves, nunca os valores (critério 5)', () => {
+    const env: NodeJS.ProcessEnv = {}
+    const aplicadas = carregarEnv(escrever('SEGREDO=nao-pode-vazar'), env)
+
+    // O retorno vai para o log. Um retorno com valores despejaria credencial em disco a cada
+    // boot — e o log é o lugar de onde ela sairia sem ninguém notar.
+    expect(aplicadas).toEqual(['SEGREDO'])
+    expect(JSON.stringify(aplicadas)).not.toContain('nao-pode-vazar')
+  })
+})
+
+describe('precedência: ambiente vence arquivo (critério 2)', () => {
+  it('não sobrescreve variável já presente no ambiente', () => {
+    const env: NodeJS.ProcessEnv = { SUPABASE_URL: 'https://do-ci.supabase.co' }
+    const aplicadas = carregarEnv(escrever('SUPABASE_URL=https://do-arquivo.supabase.co'), env)
+
+    // Se o arquivo vencesse, um `.env` esquecido no disco derrubaria em silêncio a
+    // configuração do CI — surpresa cara e difícil de rastrear.
+    expect(env.SUPABASE_URL).toBe('https://do-ci.supabase.co')
+    expect(aplicadas).toEqual([])
+  })
+
+  it('aplica só as chaves ausentes, deixando as demais intactas', () => {
+    const env: NodeJS.ProcessEnv = { JA_EXISTE: 'do-ambiente' }
+    const aplicadas = carregarEnv(escrever('JA_EXISTE=do-arquivo\nNOVA=do-arquivo'), env)
+
+    expect(env.JA_EXISTE).toBe('do-ambiente')
+    expect(env.NOVA).toBe('do-arquivo')
+    expect(aplicadas).toEqual(['NOVA'])
+  })
+
+  it('string vazia no ambiente conta como definida e não é sobrescrita', () => {
+    // `SUPABASE_URL=` exportado no shell é uma decisão de quem exportou: "quero esta variável
+    // vazia". A guarda é `!== undefined`, não truthiness — trocá-la por `!env[chave]` faria o
+    // arquivo repovoar uma variável deliberadamente esvaziada.
+    const env: NodeJS.ProcessEnv = { VAZIA: '' }
+    carregarEnv(escrever('VAZIA=do-arquivo'), env)
+
+    expect(env.VAZIA).toBe('')
+  })
+})
+
+describe('ausência do arquivo não derruba nada (critério 3)', () => {
+  it('arquivo inexistente devolve lista vazia sem lançar', () => {
+    const env: NodeJS.ProcessEnv = {}
+    // Rodar sem `.env` é caminho suportado: o app sobe com o usuário local e só o login fica
+    // indisponível (`.env.example`). Lançar aqui derrubaria o boot de quem clona o repo.
+    expect(() => carregarEnv(join(dir, 'nao-existe'), env)).not.toThrow()
+    expect(carregarEnv(join(dir, 'nao-existe'), env)).toEqual([])
+    expect(env).toEqual({})
+  })
+
+  it('diretório no lugar do arquivo também é tolerado', () => {
+    const env: NodeJS.ProcessEnv = {}
+    expect(carregarEnv(dir, env)).toEqual([])
+  })
+})
+
+describe('o elo que faltava: arquivo no disco habilita o login', () => {
+  it('com `.env` carregado, readSupabaseConfig() devolve a configuração', () => {
+    const env: NodeJS.ProcessEnv = {}
+    carregarEnv(
+      escrever(
+        [
+          '# Supabase',
+          'SUPABASE_URL=https://projeto.supabase.co',
+          'SUPABASE_PUBLISHABLE_KEY=sb_publishable_abc123'
+        ].join('\n')
+      ),
+      env
+    )
+
+    // Este é o bug do #43 na sua forma mais direta. Antes da correção, `readSupabaseConfig`
+    // devolvia `undefined` com o arquivo preenchido — e o app exibia "credenciais ausentes",
+    // indistinguível de quem nunca configurou nada.
+    expect(readSupabaseConfig(env)).toEqual({
+      url: 'https://projeto.supabase.co',
+      publishableKey: 'sb_publishable_abc123'
+    })
+  })
+
+  it('sem arquivo, readSupabaseConfig() segue devolvendo undefined', () => {
+    const env: NodeJS.ProcessEnv = {}
+    carregarEnv(join(dir, 'nao-existe'), env)
+
+    // O contorno importa tanto quanto o caso feliz: a degradação graciosa continua de pé.
+    expect(readSupabaseConfig(env)).toBeUndefined()
+  })
+
+  it('`.env` com chave declarada e vazia não habilita o login', () => {
+    const env: NodeJS.ProcessEnv = {}
+    carregarEnv(escrever('SUPABASE_URL=\nSUPABASE_PUBLISHABLE_KEY='), env)
+
+    // Meio-preenchido é pior que vazio: o app tentaria falar com uma URL em branco e falharia
+    // no provedor, com mensagem errada. `readSupabaseConfig` já trata o vazio — o teste trava
+    // a combinação das duas peças.
+    expect(readSupabaseConfig(env)).toBeUndefined()
+  })
+})

--- a/src/main/env.ts
+++ b/src/main/env.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs'
+
+/**
+ * Carga do arquivo `.env` para `process.env` (FIX #43).
+ *
+ * O `.env.example` promete que preencher o arquivo habilita o login (SPEC-Fundacao-03), mas
+ * nada no projeto lia o arquivo: `readSupabaseConfig()` consulta `process.env` cru. Com as
+ * variáveis só no disco, o app degradava para "credenciais ausentes" — o mesmo estado de quem
+ * nunca configurou nada. Quem clonasse o repo e seguisse o `.env.example` batia nisso sem
+ * nenhum sinal de que o arquivo fora ignorado.
+ *
+ * Implementado à mão em vez de instalar `dotenv`: são ~20 linhas para o formato que este
+ * projeto usa, contra uma dependência de runtime no processo main. O parser cobre o que o
+ * `.env.example` contém — comentários, linhas vazias, aspas opcionais — e nada além. Se o
+ * formato crescer (multilinha, interpolação `${}`), a troca por `dotenv` é o caminho; inventar
+ * um parser completo aqui seria resolver problema que não temos.
+ */
+
+/**
+ * Interpreta o conteúdo de um `.env`.
+ *
+ * Exportado para o teste afirmar sobre o parsing sem tocar disco — e porque separar "ler o
+ * arquivo" de "entender o texto" mantém a parte com regra testável sem `fs`.
+ */
+export function parseEnv(conteudo: string): Record<string, string> {
+  const saida: Record<string, string> = {}
+
+  for (const linha of conteudo.split(/\r?\n/)) {
+    const texto = linha.trim()
+    // Comentário e linha vazia são ruído; `#` só conta no início da linha, porque um `#` no
+    // meio de um valor é caractere legítimo (aparece em chave e em cor hex).
+    if (texto === '' || texto.startsWith('#')) continue
+
+    const igual = texto.indexOf('=')
+    if (igual === -1) continue
+
+    const chave = texto.slice(0, igual).trim()
+    if (chave === '') continue
+
+    let valor = texto.slice(igual + 1).trim()
+    // Aspas envolventes são delimitador, não conteúdo: `KEY="valor"` vale `valor`. Só quando
+    // abrem **e** fecham — uma aspa solta é parte do valor.
+    const aspas = valor.startsWith('"') && valor.endsWith('"')
+    const apostrofos = valor.startsWith("'") && valor.endsWith("'")
+    if (valor.length >= 2 && (aspas || apostrofos)) valor = valor.slice(1, -1)
+
+    saida[chave] = valor
+  }
+
+  return saida
+}
+
+/**
+ * Aplica o `.env` a `process.env`, sem sobrescrever o que já existe.
+ *
+ * A precedência é deliberada: **ambiente vence arquivo**. É o que permite ao CI injetar
+ * valores próprios e a quem desenvolve sobrepor uma variável pontual sem editar o arquivo. O
+ * inverso — arquivo vencendo — faria um `.env` esquecido no disco silenciosamente derrubar a
+ * configuração do CI, que é exatamente o tipo de surpresa que custa uma tarde.
+ *
+ * Arquivo ausente ou ilegível **não** é erro: rodar sem `.env` é um caminho suportado (o app
+ * sobe com o usuário local e só o login fica indisponível). Derrubar o boot aqui contrariaria
+ * a degradação graciosa que o `.env.example` documenta.
+ *
+ * @returns os nomes das chaves aplicadas — nunca os valores, que são credenciais.
+ */
+export function carregarEnv(
+  caminho: string,
+  env: NodeJS.ProcessEnv = process.env
+): readonly string[] {
+  let conteudo: string
+  try {
+    conteudo = readFileSync(caminho, 'utf8')
+  } catch {
+    return []
+  }
+
+  const aplicadas: string[] = []
+  for (const [chave, valor] of Object.entries(parseEnv(conteudo))) {
+    if (env[chave] !== undefined) continue
+    env[chave] = valor
+    aplicadas.push(chave)
+  }
+
+  return aplicadas
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,6 +14,7 @@ import { WorkflowRepository } from './workflows/workflow-repository'
 import { AutomationRepository } from './workflows/automation-repository'
 import { SimulationEngine } from './execution/simulation-engine'
 import { ExecutionRepository } from './execution/execution-repository'
+import { carregarEnv } from './env'
 import { closeLogger, initLogger, log } from './logging/logger'
 import { initRendererLogBridge } from './logging/renderer-bridge'
 import { LOCAL_USER_ID, LOCAL_USER_PROFILE } from './storage/local-user'
@@ -53,6 +54,21 @@ if (!app.requestSingleInstanceLock()) {
       electron: process.versions.electron,
       plataforma: process.platform
     })
+
+    /*
+     * Carga do `.env` (FIX #43), depois do logger e **antes** de `criarAuthService`, que é o
+     * primeiro a ler `process.env`. Depois do logger de propósito: `writeLog` engole a linha
+     * enquanto o logger não existe, e "o arquivo foi lido?" foi exatamente a pergunta que este
+     * bug deixou sem resposta por uma fatia inteira — o sinal precisa chegar ao disco.
+     *
+     * Só fora do empacotado: um app instalado lê configuração do sistema, não um arquivo de
+     * desenvolvimento ao lado do binário. Vão para o log os **nomes** das chaves, nunca os
+     * valores, que são credenciais.
+     */
+    if (!app.isPackaged) {
+      const aplicadas = carregarEnv(join(app.getAppPath(), '.env'))
+      log.sistema.info('Carga do .env concluída', { chaves: aplicadas })
+    }
 
     // Storage depois do logger, antes dos handlers — que já podem consultá-lo.
     const storage = initStorage(app.getPath('userData'))


### PR DESCRIPTION
`refs #43`

## O problema

O `.env.example` promete que preencher o arquivo habilita o login (SPEC-Fundacao-03), mas **nada no projeto lia o arquivo**. `readSupabaseConfig()` consulta `process.env` cru e `dotenv` não existe no repo — as variáveis no disco nunca chegavam ao processo.

Com o `.env` corretamente preenchido, o app exibia:

> O aplicativo não está configurado para login. Verifique as credenciais no arquivo .env.

Cada peça estava correta isoladamente. A degradação graciosa (sem credencial ⇒ o app sobe e só o login fica indisponível) é comportamento desejado e documentado. Faltava o elo que lê o arquivo.

## Por que passou despercebido

O login foi exercitado na entrega da F03 com as variáveis **exportadas no shell** daquela sessão. O arquivo em disco nunca foi lido por ninguém.

O que torna esse defeito difícil de ver: ele se disfarça do estado esperado. "Funcionou na minha máquina" e "funciona a partir do repo" produziam telas idênticas — e a tela era exatamente a de quem nunca configurou nada. Efeito colateral: qualquer pessoa que clonasse o repo e seguisse o `.env.example` batia nisso sem nenhum sinal de que o arquivo fora ignorado.

## A correção

`src/main/env.ts` — parser próprio de ~20 linhas, chamado no boot antes de `criarAuthService()`.

**Sem `dotenv`.** O formato que o `.env.example` usa (comentários, linhas vazias, aspas opcionais, `=` e `#` dentro do valor) cabe em 20 linhas; uma dependência de runtime no processo main não se paga por isso. Se o formato crescer (multilinha, interpolação `${}`), a troca por `dotenv` é o caminho — inventar um parser completo agora seria resolver problema que não temos.

**Precedência: ambiente vence arquivo.** É o que permite ao CI injetar valores próprios e a quem desenvolve sobrepor uma variável sem editar o arquivo. O inverso faria um `.env` esquecido no disco derrubar em silêncio a configuração do CI. A guarda é `!== undefined`, não truthiness: uma variável exportada vazia é decisão de quem exportou.

**Só fora do empacotado** (`!app.isPackaged`): um app instalado lê configuração do sistema, não um arquivo de desenvolvimento ao lado do binário.

**Depois do `initLogger`**, de propósito: `writeLog` engole a linha enquanto o logger não existe, e *"o arquivo foi lido?"* foi exatamente a pergunta que este bug deixou sem resposta por uma fatia inteira. Vão para o log os **nomes** das chaves, nunca os valores.

## Verificação

**15 testes** em `src/main/env.int-spec.ts` (categoria Banco — toca disco), cobrindo os critérios do card:

| Critério | Teste |
|---|---|
| 1 — arquivo habilita o login | `readSupabaseConfig()` devolve config a partir do `.env` carregado |
| 2 — ambiente prevalece | variável do shell não é sobrescrita; string vazia conta como definida |
| 3 — ausência não derruba | arquivo inexistente e diretório no lugar do arquivo devolvem `[]` sem lançar |
| 5 — sem vazamento | o retorno traz nomes de chave, nunca valores |

Parsing coberto no que erra em silêncio: `=` final de chave base64, `#` de cor hex e `?b=c` de URL continuam íntegros — cortar no primeiro `=` truncaria credencial deixando-a *quase* certa.

**Mutações verificadas:**
- desligar a carga → **4 vermelhos**
- trocar a guarda de precedência por truthiness → **1 vermelho**

**No app real** (a prova que interessa), com as 4 variáveis removidas do shell:

```
Carga do .env concluída  chaves:[SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET]
Login solicitado pela interface → Fluxo de login aberto no navegador do sistema
Tokens da sessão gravados cifrados no cofre
Login concluído  expiresAt: 2026-08-22
```

Junto, dois comportamentos da SPEC-Fundacao-03 vistos rodando fora do teste pela primeira vez: tokens cifrados via DPAPI e a sessão de 30 dias do ADR-001 §2.

## Piso

`npm test` 426 ✓ (+15) · `npm run lint` ✓ · `npm run typecheck` ✓

## Notas

- Achado ao subir o app para inspeção visual durante a **F03b (#20)**; não misturado naquela fatia — branch e PR próprios, a partir da `main`.
- **A porta efêmera do loopback não é bug.** Dois logins consecutivos usaram portas diferentes (`58872` e `59355`) e ambos fecharam — a allowlist do Supabase aceita o wildcard. `PORTA_EFEMERA = 0` fica como está.
- Fora do escopo, do ambiente da máquina e não do repo: `ELECTRON_RUN_AS_NODE=1` setado no shell derruba o `npm run dev` com `does not provide an export named 'BrowserWindow'` — erro que se disfarça de falha de bundle, já registrado no `DEVELOPMENT.md` da F03.

## Test plan

- [x] `npm test` verde (426, +15)
- [x] `npm run lint` e `npm run typecheck` verdes
- [x] Mutação nos dois pontos de risco (carga e precedência)
- [x] Login ponta a ponta no app real com o shell limpo
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
