### PR TITLE
fix: o include de Regras não alcançava src/renderer (MVP-001)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,12 +34,23 @@ Postgres; o "banco" é a persistência local, ver ADR-001 e a SPEC-Fundacao-04):
 
 | Categoria | Camada | O que prova | Stack | Velocidade |
 |---|---|---|---|---|
-| **Regras de Negócio** | Unidade (base) | Lógica de domínio pura: uma função/regra/policy faz o que deve, isolada de storage, IPC e rede | Vitest — `src/shared/**/*.spec.ts` e `src/main/**/*.spec.ts` | rápida (ms) |
+| **Regras de Negócio** | Unidade (base) | Lógica de domínio pura: uma função/regra/policy faz o que deve, isolada de storage, IPC e rede | Vitest — `src/{shared,main,design,renderer}/**/*.spec.ts` | rápida (ms) |
 | **Banco** | Integração (meio) | Storage real, não dublê: **SQLite** (`better-sqlite3`) contra arquivo temporário, round-trip IPC↔runtime↔storage — e, desde a M2-F01, a **RLS do Supabase local** contra a stack Docker | Vitest — `src/main/**/*.int-spec.ts` e `tests/**/*.int-spec.ts` | média (s) |
 | **Tela** | Componente + E2E (topo) | UI: componente renderiza/reage certo (Vitest + Testing Library + jsdom) e fluxo crítico funciona no app real (Playwright-Electron) | Vitest — `src/renderer/**/*.test.tsx`; Playwright — `e2e/**/*.spec.ts` | componente rápida / e2e lenta |
 
 Notas de aprendizado:
 
+- **A categoria é definida pelo que o teste prova, não pela pasta onde ele mora.** A extensão é
+  que separa: `*.spec.ts` é unidade pura, `*.int-spec.ts` toca storage, `*.test.tsx` renderiza
+  componente. O `include` de **Regras** cobre `src/{shared,main,design,renderer}` — inclusive o
+  renderer, porque lógica pura pode morar ao lado da UI que a consome (`workspace/navegacao.ts` é
+  estado sem React). Componente React continua fora de Regras pela extensão, não pelo caminho.
+  Isto é registro de um bug real: o padrão original omitia `src/renderer`, e
+  `workspace/navegacao.spec.ts` **nunca rodou** — 75 linhas cobrindo o isolamento de rota por
+  espaço (SPEC-Fundacao-02, critérios 1 e 5) ficaram fora de toda categoria por três MVPs, sem
+  nada falhar. Corrigido no card [#47](https://github.com/RodReis/rrb-jarvisOS/issues/47).
+  **Um teste que não roda é indistinguível de um teste que não existe** — e é pior, porque a
+  tabela do relatório sugere cobertura que não há.
 - **Clientes externos são mockados no boundary.** Supabase (auth/sync) e Google OAuth **nunca**
   são chamados de verdade num teste. Casa com a regra de arquitetura "renderer nunca acessa Node,
   segredo ou rede direto" e com o fail-closed do Policy Engine — no teste, mock. Testa-se *o nosso

--- a/reports/TESTS.md
+++ b/reports/TESTS.md
@@ -12,7 +12,7 @@ Totais da última execução (regenerado, não acumulado):
 
 | Data | Issue | SPEC | Categoria | Testes | Pass | Falha | Cobertura % | PR | Link PR |
 |------|-------|------|-----------|-------:|-----:|------:|------------:|----:|--------|
-| — | — | — | Regras de Negócio | 203 | 203 | 0 | 77.5 | — | — |
+| — | — | — | Regras de Negócio | 212 | 212 | 0 | 78.0 | — | — |
 | — | — | — | Banco | 132 | 132 | 0 | 85.5 | — | — |
 | — | — | — | Tela | 169 | 168 | 0 | 90.7 | — | — |
 
@@ -73,3 +73,6 @@ Append-only — linhas de entregas passadas são imutáveis.
 | 2026-07-23 | #23 | spec-design-system-05-identidades | Regras de Negócio | 203 | 203 | 0 | 77.5 | #46 | [#46](https://github.com/RodReis/rrb-jarvisOS/pull/46) |
 | 2026-07-23 | #23 | spec-design-system-05-identidades | Banco | 132 | 132 | 0 | 85.5 | #46 | [#46](https://github.com/RodReis/rrb-jarvisOS/pull/46) |
 | 2026-07-23 | #23 | spec-design-system-05-identidades | Tela | 169 | 168 | 0 | 90.7 | #46 | [#46](https://github.com/RodReis/rrb-jarvisOS/pull/46) |
+| 2026-07-23 | #47 | — | Regras de Negócio | 212 | 212 | 0 | 78.0 | #48 | [#48](https://github.com/RodReis/rrb-jarvisOS/pull/48) |
+| 2026-07-23 | #47 | — | Banco | 132 | 132 | 0 | 85.5 | #48 | [#48](https://github.com/RodReis/rrb-jarvisOS/pull/48) |
+| 2026-07-23 | #47 | — | Tela | 169 | 168 | 0 | 90.7 | #48 | [#48](https://github.com/RodReis/rrb-jarvisOS/pull/48) |

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,7 +31,15 @@ export default defineConfig({
           // `src/design/tokens` entra aqui (e não em `tela`) porque é regra pura: a camada
           // não depende de React, e o ambiente `node` é o que **prova** isso — um teste em
           // jsdom passaria mesmo se o token importasse React por engano.
-          include: ['src/{shared,main,design}/**/*.spec.ts']
+          //
+          // `src/renderer` também entra, e a omissão dele era um **bug**: o padrão anterior
+          // (`src/{shared,main,design}`) deixava `workspace/navegacao.spec.ts` fora de toda
+          // categoria — 75 linhas de teste do isolamento de rota por espaço (SPEC-Fundacao-02,
+          // critérios 1 e 5) que nunca rodaram desde que foram escritas. A regra da categoria é
+          // *"unidade pura"*, não *"não fica no renderer"*: `navegacao.ts` é estado sem React,
+          // exatamente o que `regras` mede. Componente React continua fora — ele é `.test.tsx`,
+          // que este padrão não alcança. Ver o card [FIX] correspondente.
+          include: ['src/{shared,main,design,renderer}/**/*.spec.ts']
         }
       },
       {


### PR DESCRIPTION
`refs #47`

## O bug

`src/renderer/src/workspace/navegacao.spec.ts` **nunca foi executado** desde que foi escrito (MVP-001 · F02, PR #28). São 75 linhas cobrindo o isolamento de rota por espaço — critérios 1 e 5 da SPEC-Fundacao-02, incluindo *"`Desenvolvimento` não é rota de nenhum espaço"*.

O `include` da categoria **Regras** era `src/{shared,main,design}/**/*.spec.ts`. O arquivo mora em `src/renderer/`, e nenhuma das outras duas categorias o alcançava: `banco` só pega `*.int-spec.ts`, `tela` só pega `*.test.tsx`.

Verificado com `vitest run --reporter=verbose`: zero ocorrências de `navegacao.spec` na execução completa.

## O comportamento correto já estava escrito

`docs/TESTING.md` §2/§3 e o ADR-003 definem **Regras de Negócio** como *"unidade pura — sem storage/IPC/rede"*. O cabeçalho do próprio `vitest.config.ts` repete isso, e `navegacao.ts` declara a intenção na primeira linha: *"Estado puro, sem React: assim a regra é testável direto, sem renderizar componente."*

A régua é **"unidade pura"**, não **"não mora no renderer"**. A exclusão existia para manter componente React fora de `regras` — e isso segue garantido pela extensão: componente é `.test.tsx`, que o padrão `*.spec.ts` não alcança.

## Efeito

`include: ['src/{shared,main,design,renderer}/**/*.spec.ts']`

- Categoria Regras: **203 → 212** (+9). Todos passam — os testes estavam corretos, só nunca tinham rodado.
- Suíte completa: 500 → **509**.

## Verificação

- `npm run test` — 509 passed, 1 todo
- `npm run typecheck` ✓ · `npm run lint` ✓

## Por que `[FIX]` e não fatia

Não havia comportamento a decidir: o certo já está no `TESTING.md` §2/§3 e no ADR-003. Só a projeção do `include` divergia da regra documentada.

Achado durante a F04a (#21), ao estender `navegacao.ts` com o rail dual do JARVIS — o teste novo não rodava, e a investigação mostrou que os antigos também não. Corrigido em branch próprio, **sem misturar na fatia**.