### PR TITLE
fix: o Meter escondia o rótulo em aria-label

### DIFF
--- a/reports/TESTS.md
+++ b/reports/TESTS.md
@@ -14,7 +14,7 @@ Totais da última execução (regenerado, não acumulado):
 |------|-------|------|-----------|-------:|-----:|------:|------------:|----:|--------|
 | — | — | — | Regras de Negócio | 230 | 230 | 0 | 78.9 | — | — |
 | — | — | — | Banco | 132 | 132 | 0 | 85.5 | — | — |
-| — | — | — | Tela | 210 | 209 | 0 | 92.0 | — | — |
+| — | — | — | Tela | 211 | 210 | 0 | 92.0 | — | — |
 
 ## Histórico por entrega
 
@@ -85,3 +85,6 @@ Append-only — linhas de entregas passadas são imutáveis.
 | 2026-07-23 | #24 | spec-design-system-06-adocao-hardening | Regras de Negócio | 230 | 230 | 0 | 78.9 | #51 | [#51](https://github.com/RodReis/rrb-jarvisOS/pull/51) |
 | 2026-07-23 | #24 | spec-design-system-06-adocao-hardening | Banco | 132 | 132 | 0 | 85.5 | #51 | [#51](https://github.com/RodReis/rrb-jarvisOS/pull/51) |
 | 2026-07-23 | #24 | spec-design-system-06-adocao-hardening | Tela | 210 | 209 | 0 | 92.0 | #51 | [#51](https://github.com/RodReis/rrb-jarvisOS/pull/51) |
+| 2026-07-23 | #52 | spec-design-system-03b-componentes-dados-overlays | Regras de Negócio | 230 | 230 | 0 | 78.9 | #53 | [#53](https://github.com/RodReis/rrb-jarvisOS/pull/53) |
+| 2026-07-23 | #52 | spec-design-system-03b-componentes-dados-overlays | Banco | 132 | 132 | 0 | 85.5 | #53 | [#53](https://github.com/RodReis/rrb-jarvisOS/pull/53) |
+| 2026-07-23 | #52 | spec-design-system-03b-componentes-dados-overlays | Tela | 211 | 210 | 0 | 92.0 | #53 | [#53](https://github.com/RodReis/rrb-jarvisOS/pull/53) |

--- a/src/design/prova/jornada/JarvisHud.tsx
+++ b/src/design/prova/jornada/JarvisHud.tsx
@@ -85,6 +85,8 @@ export function JarvisHud({
                   maximo={100}
                   rotulo={item.nome}
                   faixas={FAIXAS_DE_RECURSO}
+                  // Quatro barras sem nome sao quatro numeros sem medida.
+                  rotuloVisivel
                 />
               ))}
             </div>

--- a/src/design/prova/jornada/jornada.test.tsx
+++ b/src/design/prova/jornada/jornada.test.tsx
@@ -194,4 +194,18 @@ describe('critério 5 — nenhum estado essencial só por cor', () => {
     expect(screen.getByText('82')).toBeInTheDocument()
     expect(screen.getByText('34')).toBeInTheDocument()
   })
+
+  it('cada barra do HUD tem o nome da medida **visível**, não só em `aria-label`', () => {
+    render(<JarvisHud uiTheme="dark" />)
+
+    // A captura mostrou quatro barras com números à direita e nenhuma forma de saber qual era
+    // CPU, RAM, GPU ou DISK: o rótulo vivia só no `aria-label`. Acessível a quem usa leitor de
+    // tela, **invisível** para quem enxerga — o inverso do critério 5.
+    //
+    // `getByText` não vê `aria-label`, e é isso que torna a asserção honesta: ela falha se o
+    // rótulo voltar a ser só atributo.
+    for (const medida of ['CPU', 'RAM', 'GPU', 'DISK']) {
+      expect(screen.getByText(medida)).toBeInTheDocument()
+    }
+  })
 })

--- a/src/design/ui/Indicadores.tsx
+++ b/src/design/ui/Indicadores.tsx
@@ -62,6 +62,8 @@ interface MeterProps {
    */
   readonly faixas?: ReadonlyArray<{ ate: number; tom: TomSemantico }>
   readonly formatar?: (valor: number) => string
+  /** Mostra o rótulo **ao lado da barra**. Ver o comentário no corpo do componente (F06). */
+  readonly rotuloVisivel?: boolean
 }
 
 /**
@@ -76,7 +78,8 @@ export function Meter({
   maximo = 100,
   rotulo,
   faixas,
-  formatar = (v) => String(v)
+  formatar = (v) => String(v),
+  rotuloVisivel = false
 }: MeterProps): React.JSX.Element {
   const proporcao = Math.min(1, Math.max(0, (valor - minimo) / (maximo - minimo)))
 
@@ -86,6 +89,23 @@ export function Meter({
 
   return (
     <div className="flex items-center gap-3">
+      {/*
+       * Rótulo **visível**, opcional (F06).
+       *
+       * Até a F06 o rótulo vivia só em `aria-label`: acessível a quem usa leitor de tela e
+       * invisível para quem enxerga. A captura do JARVIS HUD mostrou quatro barras com números à
+       * direita e nenhuma forma de saber qual era CPU, RAM, GPU ou DISK — o inverso exato do
+       * critério "estado nunca só por cor": informação essencial ausente da tela.
+       *
+       * É opcional porque nem todo uso precisa: no `Panel` "Passos hoje" do NOA, o título do
+       * painel já nomeia a medida, e repetir o rótulo ao lado da barra seria ruído. Quem sabe se
+       * o nome já está no contexto é quem monta a tela.
+       */}
+      {rotuloVisivel && (
+        <span className="w-16 shrink-0 font-[family-name:var(--jos-fonte-mono)] text-[length:var(--jos-texto-micro)] uppercase tracking-[var(--jos-tracking-label)] text-[var(--jos-cor-texto-suave)]">
+          {rotulo}
+        </span>
+      )}
       <div
         role="meter"
         aria-label={rotulo}


### PR DESCRIPTION
`refs #52`

## O bug

O `Meter` (F03b) põe o rótulo da medida **apenas** em `aria-label` — acessível a quem usa leitor de tela, **invisível** para quem enxerga.

Achado ao revisar a captura do JARVIS HUD para o aceite do MVP-003: quatro barras de telemetria com números à direita e **nenhuma forma de saber qual era CPU, RAM, GPU ou DISK**.

## O comportamento correto já estava escrito

- **SPEC-DesignSystem-03b, critério 4** — *"estado identificável sem cor (texto/ícone)"*
- **SPEC-DesignSystem-06, critério 5** — *"nenhum estado essencial comunicado só por cor"*

Quatro barras distinguidas apenas por posição e cor de faixa são exatamente o que esses critérios proíbem. Não é o mesmo caso do `Spinner`, cujo `sr-only` é correto: lá o rótulo diz *o que* carrega e o ícone já comunica *que* carrega. Aqui o rótulo **é** a identidade da medida.

## A correção

Prop `rotuloVisivel` no `Meter`. **Opcional, não default**: no `Panel` "Passos hoje" do NOA o título do painel já nomeia a medida, e repetir seria ruído. Quem sabe se o nome já está no contexto é quem monta a tela.

Corrigido no **componente**, não no uso — o HUD só passa a prop.

O teste usa `getByText`, que não vê `aria-label`. É o que torna a asserção honesta: ela falha se o rótulo voltar a ser só atributo.

## Verificação

- `npm run test` — **569 passed**, 1 todo (+1)
- `npm run test:prova` — 77 passed
- `npm run lint` ✓ · `npm run typecheck` ✓

Antes e depois em `reports/prova/jornada-jarvis-dark.png`.