### PR TITLE
docs: atualiza a contagem do grafo após o MVP-003

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ Priorizam cautela sobre velocidade; em tarefa trivial, bom senso.
 
 ## Grafo de conhecimento (graphify)
 
-O repo tem um grafo de conhecimento persistente em `graphify-out/` (gerado pela skill `/graphify` — https://github.com/Graphify-Labs/graphify). Ele indexa `src/` + `docs/` + `scripts/` (1596 nós, 133 comunidades — atualizado em 2026-07-23, após a F03b) e responde perguntas sobre o codebase gastando muito menos tokens que ler arquivos. O escopo exclui `.aiox-core/` e as imagens de `docs/design/` — framework de terceiros e mockups não entram no grafo.
+O repo tem um grafo de conhecimento persistente em `graphify-out/` (gerado pela skill `/graphify` — https://github.com/Graphify-Labs/graphify). Ele indexa `src/` + `docs/` + `scripts/` (1748 nós, 154 comunidades — atualizado em 2026-07-23, ao fechar o MVP-003) e responde perguntas sobre o codebase gastando muito menos tokens que ler arquivos. O escopo exclui `.aiox-core/` e as imagens de `docs/design/` — framework de terceiros e mockups não entram no grafo.
 
 - **Antes de explorar o codebase** para entender arquitetura, fluxos ou "quem chama o quê": consulte o grafo primeiro — `/graphify query "<pergunta>"` (ou `graphify query` via CLI). Só leia arquivos direto quando precisar do conteúdo exato.
 - **Achar no grafo, afirmar pelo arquivo.** A topologia localiza; ela não prova. Antes de qualquer afirmação quantitativa ou de unicidade ("é a única aresta", "só existe em X", "as cópias divergiram"), conte todas as arestas relevantes e confirme no disco (`md5sum`, `diff`, ler o trecho). Cite a granularidade que o dado tem: se o grafo guarda `source_location: "§Seção"`, não invente número de linha.


### PR DESCRIPTION
Atualiza a contagem do grafo de conhecimento no `CLAUDE.md` após o `/graphify . --update`.

Só documentação — uma linha.

## O update

O incremental re-extraiu **47 arquivos** (38 código, 7 docs, 2 imagens) acumulados desde a F03b: as fatias **F05, F04a, F04b e F06**, mais os três `[FIX]` e o README.

| | Antes | Depois |
|---|---:|---:|
| Nós | 1596 | **1748** |
| Comunidades | 133 | **154** |

Diff do grafo: +224 nós, +550 arestas (72 nós e 192 arestas removidos, substituídos pela re-extração dos arquivos alterados).

Custo desta rodada: 561k tokens de input. O `graphify-out/` **não entra no commit** — é artefato local, como o CLAUDE.md determina.

## Um achado do subagente, relatado e não executado

Ao extrair o chunk 1, o subagente notou que `.claude/settings.json` aponta quatro hooks para `.claude/hooks/office3d.js`, um arquivo que o `git status` mostra como **deletado**, com um `office3d.cjs` untracked ao lado. Tratei como observação — não é escopo desta entrega, e mexer em hook do harness sem seu aval não me cabe. Fica registrado aqui caso queira resolver.