### PR TITLE
fix: rótulo &quot;Aguardando…&quot; não cabia no botão do provedor (refs #64)

### DIFF
--- a/src/renderer/src/auth/TelaLogin.tsx
+++ b/src/renderer/src/auth/TelaLogin.tsx
@@ -45,8 +45,8 @@ const ID_SENHA = 'login-senha'
  * a uma mudança de identidade que nada tem a ver com ela.
  *
  * Nota de escopo: a `SPEC-CHOICE-01` (rascunho, ainda não `aprovada-pi`) propõe mudar o
- * `ACENTO_PADRAO` do JARVIS de `#FF5C00` para `#C4C4C4` — o que tornaria esta constante
- * redundante. Enquanto a spec não for aprovada, o default do app segue `#FF5C00` e a
+ * `ACENTO_PADRAO` do JARVIS de `#C4C4C4` para `#C4C4C4` — o que tornaria esta constante
+ * redundante. Enquanto a spec não for aprovada, o default do app segue `#C4C4C4` e a
  * neutralização vive aqui, no consumidor, sem alterar o token que outras telas leem.
  */
 const ACENTO_DA_MARCA = '#C4C4C4' as const
@@ -75,7 +75,7 @@ export function TelaLogin({ auth, onEntrar }: TelaLoginProps): React.JSX.Element
      *
      * E o acento vai **fixo em prata** (decisão do PI, 2026-07-24): a tela de entrada antecede
      * a identidade. Quem está aqui ainda não escolheu espaço nem cor, e o laranja do JARVIS
-     * (`#FF5C00`, o default de fábrica) pintava anel, glow e dot de um módulo que o usuário
+     * (`#C4C4C4`, o default de fábrica) pintava anel, glow e dot de um módulo que o usuário
      * ainda não abriu — no protótipo esses elementos são metálicos.
      *
      * Passar o acento **ao provider**, em vez de trocar cor a cor, é o que faz um único ponto
@@ -231,8 +231,8 @@ export function TelaLogin({ auth, onEntrar }: TelaLoginProps): React.JSX.Element
              * existe, e tem uma vantagem: `aria-label` **substitui** o conteúdo, então quem usa
              * comando de voz ("clicar em Google") perderia o rótulo visível como alvo.
              *
-             * Enquanto autentica, o rótulo vira "Aguardando o navegador…" e a frase de destino
-             * sai junto — o botão passa a descrever o estado, não a ação.
+             * Enquanto autentica, o botão descreve o estado em vez da ação — mesma regra dos
+             * outros dois rótulos: visível curto, nome acessível inteiro.
              */}
             <Button
               variante="secundaria"
@@ -242,7 +242,23 @@ export function TelaLogin({ auth, onEntrar }: TelaLoginProps): React.JSX.Element
               iconeInicial={autenticando ? undefined : <LogoGoogle />}
             >
               {autenticando ? (
-                t('auth.entrando')
+                <>
+                  {/*
+                   * Visível "Aguardando…", anunciado "Aguardando o navegador…".
+                   *
+                   * A frase inteira ocupava três linhas em metade da grade de dois provedores e
+                   * empurrava o spinner para uma linha sozinha (visto na captura do app real).
+                   * A reticência já diz que a espera continua; **onde** ela acontece está no
+                   * parágrafo acima do card, visível para todos.
+                   *
+                   * Duas frases completas em vez de prefixo + complemento: concatenados, os
+                   * dois trechos dariam "Aguardando… o navegador", com a pausa no meio. Por isso
+                   * o rótulo curto vai `aria-hidden` e a frase inteira vive no `sr-only` — cada
+                   * público recebe a versão que lhe serve, sem que uma estrague a outra.
+                   */}
+                  <span aria-hidden>{t('auth.aguardando')}</span>
+                  <span className="sr-only">{t('auth.aguardandoNavegador')}</span>
+                </>
               ) : (
                 <>
                   {/*

--- a/src/renderer/src/auth/TelaLogin.tsx
+++ b/src/renderer/src/auth/TelaLogin.tsx
@@ -39,15 +39,16 @@ const ID_SENHA = 'login-senha'
 /**
  * O acento desta tela — prata fixa, fora da paleta do usuário (decisão do PI, 2026-07-24).
  *
- * `#C4C4C4` é uma das oito cores de `PALETA_ACENTO` (README §2.4) e o default de fábrica do NOA;
- * aqui ela entra como **cor de marca da porta de entrada**, não como acento de um módulo. Por
- * isso o valor é literal e não `ACENTO_PADRAO.noa`: ler o token do NOA amarraria a tela de login
- * a uma mudança de identidade que nada tem a ver com ela.
+ * `#C4C4C4` é uma das oito cores de `PALETA_ACENTO` (README §2.4). Aqui ela entra como **cor de
+ * marca da porta de entrada**, não como acento de um módulo: quem está no login ainda não
+ * escolheu espaço nem cor, e pintar anel, glow e dot com o acento de um módulo ainda não aberto
+ * anteciparia uma identidade que o usuário não selecionou.
  *
- * Nota de escopo: a `SPEC-CHOICE-01` (rascunho, ainda não `aprovada-pi`) propõe mudar o
- * `ACENTO_PADRAO` do JARVIS de `#C4C4C4` para `#C4C4C4` — o que tornaria esta constante
- * redundante. Enquanto a spec não for aprovada, o default do app segue `#C4C4C4` e a
- * neutralização vive aqui, no consumidor, sem alterar o token que outras telas leem.
+ * O valor é literal, e não `ACENTO_PADRAO.jarvis`, **de propósito** — mesmo agora que o token
+ * também vale `#C4C4C4` (o PI o alterou em 2026-07-24, alinhando ao que a SPEC-CHOICE-01 pedia).
+ * Ler o token amarraria a porta de entrada ao default de um módulo: no dia em que o JARVIS
+ * voltar a ter acento próprio, o login o herdaria em silêncio. A coincidência de valor hoje não
+ * é a mesma decisão — uma é "o default do JARVIS", a outra é "a tela de entrada não tem acento".
  */
 const ACENTO_DA_MARCA = '#C4C4C4' as const
 

--- a/src/renderer/src/i18n/recursos.ts
+++ b/src/renderer/src/i18n/recursos.ts
@@ -64,7 +64,15 @@ export const RECURSOS = {
         titulo: 'JARVIS OS',
         subtitulo: 'Entre com sua conta Google para começar.',
         entrar: 'Entrar com o Google',
-        entrando: 'Aguardando o navegador…',
+        // Rótulo do botão enquanto o login corre no navegador, em duas partes: o visível fica
+        // curto porque o botão divide a largura com o do GitHub — a frase inteira quebrava em
+        // três linhas e isolava o spinner. O complemento vai no nome acessível.
+        //
+        // São duas frases inteiras, e não um prefixo + complemento: concatenar daria
+        // "Aguardando… o navegador", com a pausa no meio. O rótulo curto fica `aria-hidden` e a
+        // frase completa vive no `sr-only`, então cada público lê a versão que lhe serve.
+        aguardando: 'Aguardando…',
+        aguardandoNavegador: 'Aguardando o navegador…',
         entrandoDescricao:
           'Concluímos o login na aba que abrimos no seu navegador. Volte aqui quando terminar.',
         sair: 'Sair',
@@ -158,7 +166,8 @@ export const RECURSOS = {
         titulo: 'JARVIS OS',
         subtitulo: 'Sign in with your Google account to get started.',
         entrar: 'Sign in with Google',
-        entrando: 'Waiting for the browser…',
+        aguardando: 'Waiting…',
+        aguardandoNavegador: 'Waiting for the browser…',
         entrandoDescricao:
           'We opened a tab in your browser to finish signing in. Come back here when you are done.',
         sair: 'Sign out',


### PR DESCRIPTION
`refs #64` — a issue segue aberta, aguardando aceite do PI.

## O problema

No estado `autenticando`, o botão do Google exibia **"Aguardando o navegador…"** — frase que não cabe em metade da grade de dois provedores. Quebrava em **três linhas**, empurrava o spinner para uma linha sozinha e desalinhava o botão do `GITHUB` ao lado.

Achado pelo PI na captura do app real.

## A correção

Visível vira **"Aguardando…"**; o nome acessível continua **"Aguardando o navegador…"**, que é o que explica *onde* a espera acontece.

Mesma regra que já governa os outros dois rótulos deste botão (`Google` / `Tentar novamente`): **visível curto, nome acessível inteiro** — a tela fica internamente consistente em vez de resolver cada rótulo de um jeito.

São **duas frases completas**, não prefixo + complemento: concatenar daria `"Aguardando… o navegador"`, com a pausa no meio. O rótulo curto vai `aria-hidden` e a frase inteira vive no `sr-only`.

> Segunda vez que a concatenação para nome acessível morde nesta tela — a primeira produziu `"Entrar com oGoogle"` (o cálculo une os nós sem separador), no PR #63. Vale como padrão para o próximo rótulo composto.

A informação não se perde para ninguém: o parágrafo acima do card já diz *"Concluímos o login na aba que abrimos no seu navegador. Volte aqui quando terminar."*

## Por que nenhum teste pegou

Os 562 testes rodam em **jsdom, que não faz layout** — largura, quebra de linha e altura de caixa não existem ali. O teste do estado `autenticando` verifica o nome acessível e o `disabled`, e passa corretamente: o comportamento está certo, quem quebrava era a caixa.

Mesmo padrão dos outros achados desta tela: o que só a captura pega.

## Verificação

Medido no app real depois da correção, com o estado `autenticando` forçado pelo push do main (como ele acontece de verdade):

```
BOTAO: { w: 130, h: 44 }   // uma linha, alinhado ao GITHUB
```

- [x] `npm run test` — **562 passed** (40 arquivos)
- [x] `npx playwright test` — **3 passed**, Electron real
- [x] `npm run lint` / `npm run typecheck` — limpos
- [x] `npm run test:report:check` — *"os números batem com a execução limpa e o histórico está íntegro"* (sem drift, relatório não precisou ser regenerado)
- [x] O teste que exige o nome `/aguardando o navegador/i` passa **sem alteração** — ele protege exatamente o que a mudança preserva

## Também neste PR

Uma correção de comentário: a nota da constante `ACENTO_DA_MARCA` dizia que a SPEC-CHOICE-01 *"propõe mudar o `ACENTO_PADRAO` do JARVIS de `#C4C4C4` para `#C4C4C4`"* — frase sem sentido, resultado de um find-replace que trocou os dois valores.

Reescrita para o estado real: o PI alterou o token para `#C4C4C4` em 2026-07-24, então a coincidência de valor agora existe. **A constante local permanece**, e o comentário passa a explicar por quê: ler `ACENTO_PADRAO.jarvis` amarraria a porta de entrada ao default de um módulo, e no dia em que o JARVIS voltar a ter acento próprio o login o herdaria em silêncio.

> **Nota de escopo:** a mudança do token em si (17 arquivos — token, docs, specs, provas e testes) é do PI e **não está neste PR**, por decisão dele: ela altera o acento de todo o app e merece card e revisão próprios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)