### PR TITLE
[INFRA] CI: concurrency cancela runs obsoletas no mesmo PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,16 @@ on:
   pull_request:
     branches: [main]
 
+# Cancela a execução anterior quando um novo push chega no MESMO PR (card #66): sem isto,
+# empurrar três vezes seguidas deixava três suítes inteiras (~7 min cada) rodando em
+# paralelo, e só a última importa. `github.ref` agrupa por branch do PR; a `main` não passa
+# por aqui (o workflow só dispara em `pull_request`), então não há risco de cancelar o CI de
+# um merge. Runner efêmero: cancelar não deixa Supabase nem processo órfão — o ambiente
+# inteiro é descartado. Economiza minuto de runner e devolve o resultado do push atual antes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -512,7 +512,7 @@ Três `[FIX]` nasceram durante o corte e seguem em `proplan:done`, aguardando ac
 
 Ordem: **MVP-004** ([#10](https://github.com/RodReis/rrb-jarvisOS/issues/10), execução real + terminal) → MVP de providers (Corte 3, com BudgetPolicy). Ordem macro em `docs/LANDSCAPE.md` § Roadmap.
 
-### [INFRA] #34 — Separar o E2E em job de CI próprio, condicional por paths (em andamento, 2026-07-24)
+### [INFRA] #34 — Separar o E2E em job de CI próprio, condicional por paths (entregue, 2026-07-24 · PR #71)
 
 Card de infra (sem spec — fonte: decisão do PI de 2026-07-22 + ADR-003). O E2E Playwright-Electron dominava o tempo de CI (build + xvfb + keyring + boot do Electron, ~15 min) e rodava **em todo PR**, mesmo quando o PR não tocava a fronteira que o E2E prova. Passos:
 
@@ -520,9 +520,20 @@ Card de infra (sem spec — fonte: decisão do PI de 2026-07-22 + ADR-003). O E2
 - [x] **Config** (`test-report.config.json`): a categoria "Tela" perdeu o `playwrightJson` — passou a contar **só o vitest-componente**. Estado atual: Tela 215 (era 218 com os 3 do E2E somados). `readPlaywrightJson` fica no gerador (repo-agnóstico), sem chamador, apontado no comentário.
 - [x] **`ci.yml`**: três jobs. `test` (relatório, sem E2E), `e2e` (todos os steps de ambiente — binário, setuid, keyring, build, xvfb — só quando o PR toca a fronteira) e `gate` (required check único que agrega `test` + `e2e`). Um job `changes` faz `git diff` contra a base e casa `src/main/preload/**`, `src/main/index.ts`, `src/main/window.ts`, `tests/e2e/**`, `playwright.config.ts` — sem action de terceiros (`paths:` no evento cancelaria o workflow inteiro).
 - [x] **`docs/TESTING.md`**: §2/§3/§3.1/§6/§9 atualizadas — "Tela" no relatório = componente; E2E é check à parte condicional.
-- [ ] **Ao mergear:** trocar o required check de `test` → `gate` na branch protection (só admin). Enquanto não trocar, `gate` roda mas não barra, e `test` segue sendo o gate — o E2E não bloquearia. Por isso a troca é parte da entrega.
+- [x] **Ao mergear:** required check trocado de `test` → `gate` na branch protection (feito pelo PI — é ação de admin, o classificador me bloqueou de mexer na proteção da `main`). Ordem seguida: trocar primeiro (gate já verde no #71, não bloqueou), mergear depois.
 
 **A decisão de projeto que fecha a garantia do card** ("o E2E completo tem de rodar no caminho para a `main`, a condicional nunca esconde regressão"): o `gate` é required em vez do `e2e`. Um required check **pulado** por `if:` fica *pending eterno* no GitHub e bloqueia o merge — a armadilha clássica de condicionar job por paths. O `gate` sempre roda (`if: always()`), lê `needs.e2e.result` e aceita `skipped` (PR não toca a fronteira) ou `success`, barrando em `failure`. Assim o E2E condicional nunca trava o merge, e um E2E que falha de verdade ainda derruba o gate.
+
+### [INFRA] #66 — Custo do GitHub Actions / `concurrency` no CI (2026-07-24 · PR #72)
+
+Card criado pelo Code quando o orçamento de Actions chegou a $3,30/$5,00 (repo privado ⇒ Actions cobrado). **Resolvido na origem pelo PI**, que tornou o repo **público** (Actions grátis e ilimitado) após a auditoria de segurança do próprio card (`.env` nunca commitado, nenhuma chave real no histórico). O card ficou aberto como guarda — *"se voltar a privado, o custo volta"*.
+
+Das opções técnicas do card, duas já haviam saído — **separar o E2E por paths** foi o #34; **validar local antes do push** é disciplina, não código. Sobrou **`concurrency`**, entregue aqui:
+
+- [x] **`ci.yml`**: bloco `concurrency` com `group: ci-${{ github.ref }}` + `cancel-in-progress: true`. Push novo no mesmo PR cancela a execução anterior — três pushes seguidos não deixam três suítes (~7 min cada) rodando em paralelo quando só a última conta. A `main` não passa por aqui (o workflow só dispara em `pull_request`), então não há risco de cancelar o CI de um merge. Runner efêmero: cancelar não deixa Supabase nem processo órfão.
+- [x] **`docs/TESTING.md` §6**: `concurrency` documentado na descrição dos disparos.
+
+Efeito mensurável do #34 + #66 juntos: o PR fora da fronteira roda `test` (~4 min) e pula o `e2e` (~15 min); pushes repetidos param de empilhar. O custo de Actions cai mesmo se o repo voltar a privado.
 
 ## Registro de entregas
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -8,9 +8,10 @@ Atualizado em: **2026-07-24**. Mantido pelo Code a cada entrega (junto com `DEVE
 
 | Issue | Fatia | MVP | Spec | Índice |
 |---|---|---|---|---|
+| [#64](https://github.com/RodReis/rrb-jarvisOS/issues/64) | — (`[FIX]`) | MVP-001 | *(sem spec — bug documentado, SPEC-Fundacao-03)* | — |
 | [#41](https://github.com/RodReis/rrb-jarvisOS/issues/41) | — (`[FIX]`) | MVP-001 | *(sem spec — bug documentado)* | — |
 
-> **`proplan:next` sem sucessor definido.** O #34 (que era o `next`) saiu para **Em Andamento** em 2026-07-24. A cabeça da fila agora é decisão do PI (item 11 abaixo): o `[FIX]` **#41** (renderer em porta variável × `strictPort`) ou o **MVP-004** ([#10](https://github.com/RodReis/rrb-jarvisOS/issues/10)). Enquanto o PI não marca, nenhum card abaixo carrega `proplan:next`.
+> **`proplan:next` sem sucessor definido.** Os dois cards de INFRA-CI (#34 E2E por paths, #66 concurrency) saíram para entrega em 2026-07-24. A cabeça da fila é decisão do PI (item 11 abaixo): o `[FIX]` **#64** (rótulo do login quebra o botão), o `[FIX]` **#41** (renderer em porta variável × `strictPort`) ou o **MVP-004** ([#10](https://github.com/RodReis/rrb-jarvisOS/issues/10)). Enquanto o PI não marca, nenhum card carrega `proplan:next`.
 
 > ✅ **MVP-003 aceito pelo PI em 2026-07-23.** As 8 fatias (#17–#24) estão `closed` + `proplan:finalizado` e o épico **[#16](https://github.com/RodReis/rrb-jarvisOS/issues/16) foi fechado**. Os três `[FIX]` que nasceram durante o corte (#43, #47, #52) seguem em `proplan:done`, aguardando aceite à parte.
 
@@ -40,6 +41,7 @@ Atualizado em: **2026-07-24**. Mantido pelo Code a cada entrega (junto com `DEVE
 | [#57](https://github.com/RodReis/rrb-jarvisOS/issues/57) | — (`[FIX]`) | MVP-001 | *(sem spec — fonte: protótipo `Login`, `01-login.png`, README §2.6)* | — | [#59](https://github.com/RodReis/rrb-jarvisOS/pull/59) | 2026-07-24 |
 | [#58](https://github.com/RodReis/rrb-jarvisOS/issues/58) | — (`[FIX]`) | MVP-003 | *(sem spec — fonte: `src/design/README.md` § Base técnica)* | — | [#59](https://github.com/RodReis/rrb-jarvisOS/pull/59) | 2026-07-24 |
 | [#69](https://github.com/RodReis/rrb-jarvisOS/issues/69) | CHOICE seleção de espaço + acento | *(container em aberto)* | `spec-choice-01-selecao-de-espaco.md` | — | [#70](https://github.com/RodReis/rrb-jarvisOS/pull/70) | 2026-07-24 |
+| [#34](https://github.com/RodReis/rrb-jarvisOS/issues/34) | — (`[INFRA]`) | — | *(sem spec — fonte: PI 2026-07-22 + ADR-003)* | — | [#71](https://github.com/RodReis/rrb-jarvisOS/pull/71) | 2026-07-24 |
 
 > **04 e 02 saíram no mesmo PR**, por decisão do PI (2026-07-22): o critério 4 da SPEC-04 exige `AuditEvent` de `workspace-switch`, cujo fluxo nasce na F02 — separá-las exigiria um stub que a F02 jogaria fora. O critério 4 fica **parcialmente atendido**: `workspace-switch` está provado ponta a ponta; `login`/`logout`/`login-offline-reuse` têm o tipo no contrato e o fluxo nasce na F03.
 
@@ -71,9 +73,11 @@ Atualizado em: **2026-07-24**. Mantido pelo Code a cada entrega (junto com `DEVE
 
 | Issue | Fatia | MVP | Spec | Coluna |
 |---|---|---|---|---|
-| [#34](https://github.com/RodReis/rrb-jarvisOS/issues/34) | — (`[INFRA]`) | — | *(sem spec — infra)* | Em Andamento (`proplan:doing`) |
+| [#66](https://github.com/RodReis/rrb-jarvisOS/issues/66) | — (`[INFRA]`) | — | *(sem spec — infra)* | Em Andamento (`proplan:doing`) |
 
-> **#34 em andamento** (Code, 2026-07-24) — separar o E2E do CI em job próprio, condicional por `paths`. Branch `feat/ci-e2e-job-condicional`. Três jobs no `ci.yml`: `test` (relatório, sem E2E), `e2e` (build+xvfb+keyring+Playwright, só quando o PR toca a fronteira preload/IPC/janela) e `gate` (required check, agrega os dois). Categoria "Tela" do relatório passou a contar **só vitest-componente** (215, era 218 com E2E). Fonte da decisão: PI (2026-07-22) + ADR-003. **Ao mergear:** trocar o required check de `test` → `gate` na branch protection.
+> **#66 em andamento** (Code, 2026-07-24) — `concurrency` no `ci.yml`: cancela a execução anterior quando chega push novo no mesmo PR (não deixa suítes paralelas obsoletas rodando). Branch `feat/ci-concurrency`. O card já estava **resolvido na origem** (o PI tornou o repo público → Actions grátis); segue aberto como guarda "se voltar a privado". As outras opções do card já saíram: **separar o E2E por paths** foi o **#34** (mergeado); **validar local antes do push** é disciplina do Code. `concurrency` é a última peça codificável.
+
+> **#34 entregue** (Code, 2026-07-24) — PR [#71](https://github.com/RodReis/rrb-jarvisOS/pull/71) **mergeado** (squash `05835c5`), CI verde: `test` ✅, `e2e` **skipped** (o PR não toca a fronteira), `gate` ✅ — a primeira prova do mecanismo. Três jobs (`test`/`e2e`/`gate`) + `changes`; "Tela" no relatório = só vitest (215). Required check trocado `test` → `gate`. `proplan:done`, aguardando aceite do PI.
 
 > **#69 CHOICE entregue** (Code, 2026-07-24) — PR [#70](https://github.com/RodReis/rrb-jarvisOS/pull/70) **mergeado** (squash `0d4e42d`), CI verde. Os **11 critérios** entregues num PR só (os dois PRs planejados viraram dois commits na mesma branch). `TelaChoice` fiel ao protótipo, acento persistido no `UserProfile` (migration 6), Settings com o mesmo seletor. Rail e `WorkspaceSwitcher` **intactos** (opção A). Aguarda **aceite do PI** (`proplan:done`). O `proplan:next` volta ao #34 (INFRA), a cabeça da fila.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -275,8 +275,10 @@ registradas no código de referência da §10):
 
 ## 6. Workflow de CI — `.github/workflows/ci.yml`
 
-Dispara em **todo pull request** para `main`. Desde o **card #34** (2026-07-24) são **três jobs**,
-não um:
+Dispara em **todo pull request** para `main`. Um bloco `concurrency` (card #66) cancela a execução
+anterior quando chega um push novo no mesmo PR — três pushes seguidos não deixam três suítes
+inteiras (~7 min cada) rodando em paralelo quando só a última importa. Desde o **card #34**
+(2026-07-24) são **três jobs**, não um:
 
 - **`test`** — roda em todo PR. Runners unitários/integração + relatório + guarda anti-drift
   (descrito nesta seção). **Não sobe Electron** e **não roda E2E**.


### PR DESCRIPTION
**refs #66** (não `closes` — aceite do PI).

## O quê

Adiciona `concurrency` ao `ci.yml`: um push novo no mesmo PR **cancela a execução anterior**. Sem isto, empurrar três vezes seguidas deixava três suítes inteiras (~7 min cada) rodando em paralelo quando só a última importa.

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true
```

`group` por `github.ref` (agrupa por branch do PR). A `main` não passa por aqui — o workflow só dispara em `pull_request` —, então não há risco de cancelar o CI de um merge. Runner efêmero: cancelar não deixa Supabase nem processo órfão.

## Contexto do #66

O card nasceu do orçamento de Actions ($3,30/$5,00, repo privado). **Já foi resolvido na origem:** o PI tornou o repo **público** (Actions grátis/ilimitado) após a auditoria de segurança do card. Ele segue aberto como guarda — *"se voltar a privado, o custo volta"*.

Das opções técnicas do card:
- **Separar o E2E por paths** → saiu no **#34** (mergeado).
- **Validar local antes do push** → disciplina, não código.
- **`concurrency`** → **este PR**, a última peça codificável.

Efeito de #34 + #66 juntos: PR fora da fronteira roda só `test` (~4 min) e pula o `e2e` (~15 min); pushes repetidos param de empilhar. O custo cai mesmo se o repo voltar a privado.

## Docs

`docs/TESTING.md` §6 · `docs/STATUS.md` (#34→Feito, #66→Em Andamento) · `docs/DEVELOPMENT.md`.

## Verificação

- `npm run lint` — verde.
- `ci.yml` validado por `js-yaml` (4 jobs + `concurrency` no lugar).
- Não altera teste → sem `--require-entry`; números do relatório inalterados (Tela 215), guarda anti-drift passa.